### PR TITLE
Add ability for char_map to emit length, plus a few more unit tests t…

### DIFF
--- a/src/aeon.hpp
+++ b/src/aeon.hpp
@@ -13,7 +13,7 @@
  limitations under the License.
 */
 
-#pragma once 
+#pragma once
 
 #include "loader.hpp"
 #include "etl_image.hpp"

--- a/src/api.cpp
+++ b/src/api.cpp
@@ -57,12 +57,11 @@ static PyObject* wrap_buffer_as_np_array(const buffer_fixed_size_elements* buf);
 
 typedef struct
 {
-    PyObject_HEAD
-    PyObject* ndata;
-    PyObject* batch_size;
-    PyObject* axes_info;
-    loader*  m_loader;
-    uint32_t m_i;
+    PyObject_HEAD PyObject* ndata;
+    PyObject*               batch_size;
+    PyObject*               axes_info;
+    loader*                 m_loader;
+    uint32_t                m_i;
 } aeon_Dataloader;
 
 static PyMethodDef aeon_methods[] = {{"error_out", (PyCFunction)error_out, METH_NOARGS, NULL},
@@ -104,7 +103,6 @@ static PyObject* Dataloader_iternext(PyObject* self)
                 ERR << "Error building shape string";
                 PyErr_SetString(PyExc_RuntimeError, "Error building shape dict");
             }
-
         }
         DL_get_loader(self)->get_current_iter()++;
     }
@@ -125,17 +123,16 @@ static Py_ssize_t aeon_Dataloader_length(PyObject* self)
     return DL_get_loader(self)->record_count();
 }
 
-static PySequenceMethods Dataloader_sequence_methods = {
-    aeon_Dataloader_length, /* sq_length */
-    0,                      /* sq_length */
-    0,                      /* sq_concat */
-    0,                      /* sq_repeat */
-    0,                      /* sq_item */
-    0,                      /* sq_ass_item */
-    0,                      /* sq_contains */
-    0,                      /* sq_inplace_concat */
-    0,                      /* sq_inplace_repeat */
-    0                       /* sq_inplace_repeat */};
+static PySequenceMethods Dataloader_sequence_methods = {aeon_Dataloader_length, /* sq_length */
+                                                        0,                      /* sq_length */
+                                                        0,                      /* sq_concat */
+                                                        0,                      /* sq_repeat */
+                                                        0,                      /* sq_item */
+                                                        0,                      /* sq_ass_item */
+                                                        0,                      /* sq_contains */
+                                                        0, /* sq_inplace_concat */
+                                                        0, /* sq_inplace_repeat */
+                                                        0 /* sq_inplace_repeat */};
 
 /* This function handles py2 and py3 independent unpacking of string object (bytes or unicode)
  * as an ascii std::string
@@ -303,7 +300,8 @@ static PyObject* Dataloader_new(PyTypeObject* type, PyObject* args, PyObject* kw
                     Py_DECREF(tmp_length);
                 }
 
-                int set_status = PyDict_SetItemString(self->axes_info, datum_name.c_str(), py_axis_dict);
+                int set_status =
+                    PyDict_SetItemString(self->axes_info, datum_name.c_str(), py_axis_dict);
                 Py_DECREF(py_axis_dict);
 
                 if (set_status < 0)
@@ -313,7 +311,6 @@ static PyObject* Dataloader_new(PyTypeObject* type, PyObject* args, PyObject* kw
                     return NULL;
                 }
             }
-
         }
         catch (std::exception& e)
         {
@@ -354,7 +351,7 @@ static PyMemberDef Dataloader_members[] = {
     {"ndata", T_OBJECT_EX, offsetof(aeon_Dataloader, ndata), 0, "number of records in dataset"},
     {"batch_size", T_OBJECT_EX, offsetof(aeon_Dataloader, batch_size), 0, "mini-batch size"},
     {"axes_info", T_OBJECT_EX, offsetof(aeon_Dataloader, axes_info), 0, "axes names and lengths"},
-    {NULL, NULL, 0, 0, NULL}  /* Sentinel */
+    {NULL, NULL, 0, 0, NULL} /* Sentinel */
 };
 
 static PyTypeObject aeon_DataloaderType = {
@@ -363,52 +360,52 @@ static PyTypeObject aeon_DataloaderType = {
 #else
     PyObject_HEAD_INIT(NULL) 0,
 #endif
-        "aeon.Dataloader",                     /*tp_name*/
-    sizeof(aeon_Dataloader),                   /*tp_basicsize*/
-    0,                                         /*tp_itemsize*/
-    (destructor)Dataloader_dealloc,            /*tp_dealloc*/
-    0,                                         /*tp_print*/
-    0,                                         /*tp_getattr*/
-    0,                                         /*tp_setattr*/
-    0,                                         /*tp_compare*/
-    0,                                         /*tp_repr*/
-    0,                                         /*tp_as_number*/
-    &Dataloader_sequence_methods,              /*tp_as_sequence*/
-    0,                                         /*tp_as_mapping*/
-    0,                                         /*tp_hash */
-    0,                                         /*tp_call*/
-    0,                                         /*tp_str*/
-    0,                                         /*tp_getattro*/
-    0,                                         /*tp_setattro*/
-    0,                                         /*tp_as_buffer*/
+        "aeon.Dataloader",                                           /*tp_name*/
+    sizeof(aeon_Dataloader),                                         /*tp_basicsize*/
+    0,                                                               /*tp_itemsize*/
+    (destructor)Dataloader_dealloc,                                  /*tp_dealloc*/
+    0,                                                               /*tp_print*/
+    0,                                                               /*tp_getattr*/
+    0,                                                               /*tp_setattr*/
+    0,                                                               /*tp_compare*/
+    0,                                                               /*tp_repr*/
+    0,                                                               /*tp_as_number*/
+    &Dataloader_sequence_methods,                                    /*tp_as_sequence*/
+    0,                                                               /*tp_as_mapping*/
+    0,                                                               /*tp_hash */
+    0,                                                               /*tp_call*/
+    0,                                                               /*tp_str*/
+    0,                                                               /*tp_getattro*/
+    0,                                                               /*tp_setattro*/
+    0,                                                               /*tp_as_buffer*/
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE | Py_TPFLAGS_HAVE_ITER, /*tp_flags*/
-    "Internal myiter iterator object.",        /* tp_doc */
-    0,                                         /* tp_traverse */
-    0,                                         /* tp_clear */
-    0,                                         /* tp_richcompare */
-    0,                                         /* tp_weaklistoffset */
-    Dataloader_iter,                           /* tp_iter */
-    Dataloader_iternext,                       /* tp_iternext */
-    Dataloader_methods,                        /* tp_methods */
-    Dataloader_members,                        /* tp_members */
-    0,                                         /* tp_getset */
-    0,                                         /* tp_base */
-    0,                                         /* tp_dict */
-    0,                                         /* tp_descr_get */
-    0,                                         /* tp_descr_set */
-    0,                                         /* tp_dictoffset */
-    (initproc)Dataloader_init,                 /* tp_init */
-    0,                                         /* tp_alloc */
-    Dataloader_new,                            /* tp_new */
-    0,                                         /* tp_free */
-    0,                                         /* tp_is_gc */
-    0,                                         /* tp_bases */
-    0,                                         /* tp_mro */
-    0,                                         /* tp_cache */
-    0,                                         /* tp_subclasses */
-    0,                                         /* tp_weaklist */
-    0,                                         /* tp_del */
-    0                                          /* tp_version_tag */
+    "Internal myiter iterator object.",                              /* tp_doc */
+    0,                                                               /* tp_traverse */
+    0,                                                               /* tp_clear */
+    0,                                                               /* tp_richcompare */
+    0,                                                               /* tp_weaklistoffset */
+    Dataloader_iter,                                                 /* tp_iter */
+    Dataloader_iternext,                                             /* tp_iternext */
+    Dataloader_methods,                                              /* tp_methods */
+    Dataloader_members,                                              /* tp_members */
+    0,                                                               /* tp_getset */
+    0,                                                               /* tp_base */
+    0,                                                               /* tp_dict */
+    0,                                                               /* tp_descr_get */
+    0,                                                               /* tp_descr_set */
+    0,                                                               /* tp_dictoffset */
+    (initproc)Dataloader_init,                                       /* tp_init */
+    0,                                                               /* tp_alloc */
+    Dataloader_new,                                                  /* tp_new */
+    0,                                                               /* tp_free */
+    0,                                                               /* tp_is_gc */
+    0,                                                               /* tp_bases */
+    0,                                                               /* tp_mro */
+    0,                                                               /* tp_cache */
+    0,                                                               /* tp_subclasses */
+    0,                                                               /* tp_weaklist */
+    0,                                                               /* tp_del */
+    0                                                                /* tp_version_tag */
 };
 
 #ifdef IS_PY3K

--- a/src/async_manager.hpp
+++ b/src/async_manager.hpp
@@ -51,7 +51,7 @@ class nervana::async_manager_info
 {
 public:
     virtual ~async_manager_info() {}
-    virtual async_state get_state() const = 0;
+    virtual async_state        get_state() const = 0;
     virtual const std::string& get_name() const  = 0;
 };
 
@@ -70,9 +70,8 @@ public:
 };
 
 template <typename INPUT, typename OUTPUT>
-class nervana::async_manager
-    : public nervana::async_manager_source<OUTPUT>
-    , public async_manager_info
+class nervana::async_manager : public nervana::async_manager_source<OUTPUT>,
+                               public async_manager_info
 {
 public:
     async_manager(async_manager_source<INPUT>* source, const std::string& name)
@@ -92,13 +91,14 @@ public:
         {
             m_first = false;
             // Just run this one in blocking mode
-            m_pending_result = std::async(std::launch::async, &nervana::async_manager<INPUT, OUTPUT>::filler, this);
+            m_pending_result = std::async(
+                std::launch::async, &nervana::async_manager<INPUT, OUTPUT>::filler, this);
         }
         try
         {
             result = m_pending_result.get();
         }
-        catch(std::exception& e)
+        catch (std::exception& e)
         {
             INFO << e.what();
         }
@@ -107,7 +107,8 @@ public:
             swap();
 
             // Now kick off this one in async
-            m_pending_result = std::async(std::launch::async, &nervana::async_manager<INPUT, OUTPUT>::filler, this);
+            m_pending_result = std::async(
+                std::launch::async, &nervana::async_manager<INPUT, OUTPUT>::filler, this);
         }
         return result;
     }
@@ -132,16 +133,8 @@ public:
         }
     }
 
-    async_state get_state() const override
-    {
-        return m_state;
-    }
-
-    const std::string& get_name() const override
-    {
-        return m_name;
-    }
-
+    async_state        get_state() const override { return m_state; }
+    const std::string& get_name() const override { return m_name; }
 protected:
     async_manager(const async_manager&) = delete;
     void swap()

--- a/src/augment_audio.hpp
+++ b/src/augment_audio.hpp
@@ -40,11 +40,11 @@ public:
     friend std::ostream& operator<<(std::ostream& out, const params& obj)
     {
         out << "add_noise               " << obj.add_noise << "\n";
-        out << "noise_index             " << obj.noise_index << "\n";   
-        out << "noise_level             " << obj.noise_level << "\n";    
-        out << "noise_offset_fraction   " << obj.noise_offset_fraction << "\n";         
-        out << "time_scale_fraction     " << obj.time_scale_fraction << "\n";     
-        return out;   
+        out << "noise_index             " << obj.noise_index << "\n";
+        out << "noise_level             " << obj.noise_level << "\n";
+        out << "noise_offset_fraction   " << obj.noise_offset_fraction << "\n";
+        out << "time_scale_fraction     " << obj.time_scale_fraction << "\n";
+        return out;
     }
 
     bool     add_noise;
@@ -79,7 +79,7 @@ public:
 
 private:
     std::default_random_engine m_random{0};
-    float add_noise_probability = 0.0f;
+    float                      add_noise_probability = 0.0f;
 
     std::vector<std::shared_ptr<interface::config_info_interface>> config_list = {
         // ADD_SCALAR(type, mode::REQUIRED, [](const std::string& s) { return s == "audio"; }),
@@ -97,13 +97,9 @@ private:
         // ADD_SCALAR(noise_root, mode::OPTIONAL),
         ADD_SCALAR(add_noise_probability, mode::OPTIONAL),
 
-
-
-
         ADD_DISTRIBUTION(time_scale_fraction,
                          mode::OPTIONAL,
                          [](decltype(time_scale_fraction) v) { return v.a() <= v.b(); }),
         ADD_DISTRIBUTION(
-            noise_level, mode::OPTIONAL, [](decltype(noise_level) v) { return v.a() <= v.b(); })
-    };
+            noise_level, mode::OPTIONAL, [](decltype(noise_level) v) { return v.a() <= v.b(); })};
 };

--- a/src/augment_image.cpp
+++ b/src/augment_image.cpp
@@ -57,7 +57,10 @@ augment::image::param_factory::param_factory(nlohmann::json js)
     }
 }
 
-shared_ptr<augment::image::params> augment::image::param_factory::make_params(size_t input_width, size_t input_height, size_t output_width, size_t output_height)
+shared_ptr<augment::image::params> augment::image::param_factory::make_params(size_t input_width,
+                                                                              size_t input_height,
+                                                                              size_t output_width,
+                                                                              size_t output_height)
 {
     // Must use this method for creating a shared_ptr rather than make_shared
     // since the params default ctor is private and factory is friend
@@ -66,14 +69,14 @@ shared_ptr<augment::image::params> augment::image::param_factory::make_params(si
 
     settings->output_size = cv::Size2i(output_width, output_height);
 
-    settings->angle = angle(m_dre);
-    settings->flip  = flip_distribution(m_dre);
-    settings->hue   = hue(m_dre);
-    settings->contrast = contrast(m_dre);
+    settings->angle      = angle(m_dre);
+    settings->flip       = flip_distribution(m_dre);
+    settings->hue        = hue(m_dre);
+    settings->contrast   = contrast(m_dre);
     settings->brightness = brightness(m_dre);
     settings->saturation = saturation(m_dre);
 
-    cv::Size2f input_size   = cv::Size(input_width, input_height);
+    cv::Size2f input_size = cv::Size(input_width, input_height);
     if (!crop_enable)
     {
         settings->cropbox = cv::Rect(cv::Point2f(0, 0), input_size);
@@ -92,14 +95,15 @@ shared_ptr<augment::image::params> augment::image::param_factory::make_params(si
     }
     else
     {
-        float      image_scale                 = scale(m_dre);
+        float      image_scale            = scale(m_dre);
         float      _horizontal_distortion = horizontal_distortion(m_dre);
         cv::Size2f out_shape(output_width * _horizontal_distortion, output_height);
 
         cv::Size2f cropbox_size = nervana::image::cropbox_max_proportional(input_size, out_shape);
         if (do_area_scale)
         {
-            cropbox_size = nervana::image::cropbox_area_scale(input_size, cropbox_size, image_scale);
+            cropbox_size =
+                nervana::image::cropbox_area_scale(input_size, cropbox_size, image_scale);
         }
         else
         {
@@ -109,8 +113,9 @@ shared_ptr<augment::image::params> augment::image::param_factory::make_params(si
         float c_off_x = crop_offset(m_dre);
         float c_off_y = crop_offset(m_dre);
 
-        cv::Point2f cropbox_origin = nervana::image::cropbox_shift(input_size, cropbox_size, c_off_x, c_off_y);
-        settings->cropbox          = cv::Rect(cropbox_origin, cropbox_size);
+        cv::Point2f cropbox_origin =
+            nervana::image::cropbox_shift(input_size, cropbox_size, c_off_x, c_off_y);
+        settings->cropbox = cv::Rect(cropbox_origin, cropbox_size);
     }
 
     if (lighting.stddev() != 0)

--- a/src/augment_image.hpp
+++ b/src/augment_image.hpp
@@ -40,6 +40,7 @@ namespace nervana
 class nervana::augment::image::params
 {
     friend class nervana::augment::image::param_factory;
+
 public:
     friend std::ostream& operator<<(std::ostream& out, const params& obj)
     {
@@ -77,12 +78,15 @@ class nervana::augment::image::param_factory : public json_configurable
 {
 public:
     param_factory(nlohmann::json config);
-    std::shared_ptr<params> make_params(size_t input_width, size_t input_height, size_t output_width, size_t output_height);
+    std::shared_ptr<params> make_params(size_t input_width,
+                                        size_t input_height,
+                                        size_t output_width,
+                                        size_t output_height);
 
-    bool     do_area_scale        = false;
-    bool     crop_enable          = true;
-    bool     fixed_aspect_ratio   = false;
-    float    fixed_scaling_factor = -1;
+    bool  do_area_scale        = false;
+    bool  crop_enable          = true;
+    bool  fixed_aspect_ratio   = false;
+    float fixed_scaling_factor = -1;
 
     /** Scale the crop box (width, height) */
     std::uniform_real_distribution<float> scale{1.0f, 1.0f};

--- a/src/batch_decoder.cpp
+++ b/src/batch_decoder.cpp
@@ -52,13 +52,7 @@ batch_decoder::batch_decoder(batch_iterator*                            b_itor,
             i == nthreads - 1 ? (batch_size - i * m_items_per_thread) : m_items_per_thread;
         int end = start + record_count;
         m_decode_thread_info.push_back(make_shared<decode_thread_info>(
-            i,
-            start,
-            end,
-            prov,
-            m_work_complete_event,
-            m_active_count
-        ));
+            i, start, end, prov, m_work_complete_event, m_active_count));
     }
 
     auto oshapes         = prov->get_output_shapes();
@@ -81,11 +75,11 @@ batch_decoder::~batch_decoder()
 
 fixed_buffer_map* batch_decoder::filler()
 {
-    m_state                      = async_state::wait_for_buffer;
-    fixed_buffer_map*    outputs = get_pending_buffer();
-    m_state                      = async_state::fetching_data;
-    encoded_record_list* inputs  = m_source->next();
-    m_state                      = async_state::processing;
+    m_state                     = async_state::wait_for_buffer;
+    fixed_buffer_map* outputs   = get_pending_buffer();
+    m_state                     = async_state::fetching_data;
+    encoded_record_list* inputs = m_source->next();
+    m_state                     = async_state::processing;
 
     if (inputs == nullptr)
     {

--- a/src/batch_decoder.hpp
+++ b/src/batch_decoder.hpp
@@ -31,7 +31,12 @@ namespace nervana
 class nervana::decode_thread_info
 {
 public:
-    decode_thread_info(int id, int start, int end, const std::shared_ptr<provider_interface>& prov, event& done, std::atomic<size_t>& active)
+    decode_thread_info(int                                        id,
+                       int                                        start,
+                       int                                        end,
+                       const std::shared_ptr<provider_interface>& prov,
+                       event&                                     done,
+                       std::atomic<size_t>&                       active)
         : m_id{id}
         , m_start_index{start}
         , m_end_index{end}
@@ -47,7 +52,7 @@ public:
 
     void set_buffers(encoded_record_list* in, fixed_buffer_map* out)
     {
-        m_in_buf = in;
+        m_in_buf  = in;
         m_out_buf = out;
         m_waiting_for_work_event.notify();
     }
@@ -74,7 +79,7 @@ public:
 private:
     void thread_entry()
     {
-        while(m_thread_active)
+        while (m_thread_active)
         {
             m_waiting_for_work_event.wait();
             if (m_thread_active)
@@ -114,12 +119,12 @@ public:
     }
 
 private:
-    size_t                                           m_batch_size;
-    size_t                                           m_number_elements_in;
-    size_t                                           m_number_elements_out;
-    int                                              m_items_per_thread;
+    size_t m_batch_size;
+    size_t m_number_elements_in;
+    size_t m_number_elements_out;
+    int    m_items_per_thread;
 
-    std::function<void(const fixed_buffer_map*)>     m_info_handler;
+    std::function<void(const fixed_buffer_map*)> m_info_handler;
 
     std::vector<std::shared_ptr<decode_thread_info>> m_decode_thread_info;
     event                                            m_work_complete_event;

--- a/src/block_loader_file.cpp
+++ b/src/block_loader_file.cpp
@@ -30,7 +30,8 @@ using namespace std;
 using namespace nervana;
 
 block_loader_file::block_loader_file(manifest_file* manifest, size_t block_size)
-    : async_manager<std::vector<std::vector<std::string>>, encoded_record_list>{manifest, "block_loader_file"}
+    : async_manager<std::vector<std::vector<std::string>>, encoded_record_list>{manifest,
+                                                                                "block_loader_file"}
     , m_block_size(block_size)
     , m_record_count{manifest->record_count()}
     , m_manifest(*manifest)

--- a/src/block_loader_file.hpp
+++ b/src/block_loader_file.hpp
@@ -55,12 +55,14 @@ public:
 
     async_state get_state() const override
     {
-        return async_manager<std::vector<std::vector<std::string>>, encoded_record_list>::get_state();
+        return async_manager<std::vector<std::vector<std::string>>,
+                             encoded_record_list>::get_state();
     }
 
     const std::string& get_name() const override
     {
-        return async_manager<std::vector<std::vector<std::string>>, encoded_record_list>::get_name();
+        return async_manager<std::vector<std::vector<std::string>>,
+                             encoded_record_list>::get_name();
     }
 
 private:

--- a/src/block_manager.cpp
+++ b/src/block_manager.cpp
@@ -109,7 +109,7 @@ nervana::encoded_record_list* block_manager::filler()
         {
             m_cache_miss++;
             m_state = async_state::fetching_data;
-            input = m_source->next();
+            input   = m_source->next();
             m_state = async_state::processing;
             if (input == nullptr)
             {

--- a/src/buffer_batch.cpp
+++ b/src/buffer_batch.cpp
@@ -79,10 +79,10 @@ cv::Mat buffer_fixed_size_elements::get_item_as_mat(size_t index, bool channel_m
     // INFO << ndims;
     // INFO << join(sizes, ", ");
 
-    cv::Mat ret(
-        ndims,
-        &sizes[0], CV_MAKETYPE(m_shape_type.get_otype().get_cv_type(), channels),
-        (void*)&m_data[index * m_stride]);
+    cv::Mat ret(ndims,
+                &sizes[0],
+                CV_MAKETYPE(m_shape_type.get_otype().get_cv_type(), channels),
+                (void*)&m_data[index * m_stride]);
     return ret;
 }
 

--- a/src/buffer_batch.hpp
+++ b/src/buffer_batch.hpp
@@ -159,7 +159,7 @@ public:
     virtual void allocate();
     const char* get_item(size_t index) const;
     char* get_item(size_t index);
-    cv::Mat get_item_as_mat(size_t index, bool channel_major=false) const;
+    cv::Mat get_item_as_mat(size_t index, bool channel_major = false) const;
     char*             data() const { return m_data; }
     size_t            get_item_count() const { return m_size / m_stride; }
     size_t            size() const { return m_size; }

--- a/src/etl_audio.cpp
+++ b/src/etl_audio.cpp
@@ -51,8 +51,8 @@ audio::transformer::~transformer()
 * 5. Optionally time-warp (controlled by time_scale_fraction)
 */
 std::shared_ptr<audio::decoded>
-    audio::transformer::transform(std::shared_ptr<augment::audio::params>  params,
-                                  std::shared_ptr<audio::decoded> decoded)
+    audio::transformer::transform(std::shared_ptr<augment::audio::params> params,
+                                  std::shared_ptr<audio::decoded>         decoded)
 {
     cv::Mat& samples_mat = decoded->get_time_data();
     _noisemaker->addNoise(samples_mat,

--- a/src/etl_audio.hpp
+++ b/src/etl_audio.hpp
@@ -294,7 +294,8 @@ public:
 private:
 };
 
-class nervana::audio::transformer : public interface::transformer<audio::decoded, augment::audio::params>
+class nervana::audio::transformer
+    : public interface::transformer<audio::decoded, augment::audio::params>
 {
 public:
     transformer(const audio::config& config);

--- a/src/etl_boundingbox.cpp
+++ b/src/etl_boundingbox.cpp
@@ -131,8 +131,8 @@ void boundingbox::extractor::extract(const void*                            data
         {
             b.truncated = object["truncated"];
         }
-        string name     = object["name"];
-        auto   found    = label_map.find(name);
+        string name  = object["name"];
+        auto   found = label_map.find(name);
         if (found == label_map.end())
         {
             // did not find the label in the ctor supplied label list
@@ -241,8 +241,8 @@ vector<boundingbox::box>
 }
 
 shared_ptr<boundingbox::decoded>
-    boundingbox::transformer::transform(shared_ptr<augment::image::params>        pptr,
-                                        shared_ptr<boundingbox::decoded> boxes)
+    boundingbox::transformer::transform(shared_ptr<augment::image::params> pptr,
+                                        shared_ptr<boundingbox::decoded>   boxes)
 {
     if (pptr->angle != 0)
     {

--- a/src/etl_boundingbox.hpp
+++ b/src/etl_boundingbox.hpp
@@ -64,7 +64,7 @@ public:
     size_t                   max_bbox_count;
     std::vector<std::string> class_names;
     std::string              output_type = "float";
-    std::string name;
+    std::string              name;
 
     std::unordered_map<std::string, int> label_map;
 
@@ -100,12 +100,7 @@ public:
     int                                  width() const { return m_width; }
     int                                  height() const { return m_height; }
     int                                  depth() const { return m_depth; }
-
-    cv::Size2i image_size() const override
-    {
-        return cv::Size2i(m_width, m_height);
-    }
-
+    cv::Size2i image_size() const override { return cv::Size2i(m_width, m_height); }
 private:
     std::vector<boundingbox::box> m_boxes;
     int                           m_width;
@@ -134,7 +129,8 @@ public:
     transformer(const boundingbox::config&);
     virtual ~transformer() {}
     virtual std::shared_ptr<boundingbox::decoded>
-        transform(std::shared_ptr<augment::image::params>, std::shared_ptr<boundingbox::decoded>) override;
+        transform(std::shared_ptr<augment::image::params>,
+                  std::shared_ptr<boundingbox::decoded>) override;
 
     static std::vector<boundingbox::box> transform_box(const std::vector<boundingbox::box>& b,
                                                        const cv::Rect&                      crop,

--- a/src/etl_char_map.cpp
+++ b/src/etl_char_map.cpp
@@ -31,9 +31,13 @@ nervana::char_map::config::config(nlohmann::json js)
     }
     verify_config("char_map", config_list, js);
 
-    // Now fill in derived (pack_for_ctc passed as indicator whether to interpret
-    // output shape as flattened across batch size)
-    add_shape_type({1, max_length}, {"character", "sequence"}, output_type, pack_for_ctc);
+    // Now fill in derived
+    add_shape_type({1, max_length}, {"character", "sequence"}, output_type);
+
+    if (emit_length)
+    {
+        add_shape_type({1}, "uint32_t");
+    }
 
     // set locale to operate on UTF8 input characters
     std::setlocale(LC_CTYPE, "");
@@ -83,5 +87,10 @@ void char_map::loader::load(const vector<void*>& outlist, std::shared_ptr<char_m
     for (auto c : dc->get_data())
     {
         *(outbuf++) = c;
+    }
+    if (_emit_length)
+    {
+        uint32_t* length_buf = (uint32_t*)outlist[1];
+        *length_buf          = dc->get_length();
     }
 }

--- a/src/etl_char_map.hpp
+++ b/src/etl_char_map.hpp
@@ -51,8 +51,8 @@ public:
     /** Integer value to give to unknown characters. 0 causes them to be
     * discarded.*/
     uint32_t unknown_value = 0;
-    /** Pack the output buffer for use in CTC. This places them end to end */
-    bool pack_for_ctc = false;
+    /** Whether to also output the number of valid characters per record */
+    bool emit_length = false;
     /** Output data type */
     std::string output_type{"uint32_t"};
     std::string name;
@@ -66,7 +66,7 @@ private:
         ADD_SCALAR(alphabet, mode::REQUIRED),
         ADD_SCALAR(name, mode::OPTIONAL),
         ADD_SCALAR(unknown_value, mode::OPTIONAL),
-        ADD_SCALAR(pack_for_ctc, mode::OPTIONAL),
+        ADD_SCALAR(emit_length, mode::OPTIONAL),
         ADD_SCALAR(output_type, mode::OPTIONAL, [](const std::string& v) {
             return output_type::is_valid_type(v);
         })};
@@ -143,17 +143,21 @@ public:
     virtual std::shared_ptr<char_map::decoded> extract(const void* in_array, size_t in_sz) override;
 
 private:
-    const cmap_t& _cmap; // This comes from config
-    uint32_t      _max_length;
+    const cmap_t&  _cmap; // This comes from config
+    uint32_t       _max_length;
     const uint32_t _unknown_value;
 };
 
 class nervana::char_map::loader : public interface::loader<char_map::decoded>
 {
 public:
-    loader(const char_map::config& cfg) {}
+    loader(const char_map::config& cfg)
+        : _emit_length(cfg.emit_length)
+    {
+    }
     virtual ~loader() {}
     virtual void load(const std::vector<void*>&, std::shared_ptr<char_map::decoded>) override;
 
 private:
+    const bool _emit_length;
 };

--- a/src/etl_depthmap.cpp
+++ b/src/etl_depthmap.cpp
@@ -58,8 +58,8 @@ depthmap::transformer::~transformer()
 }
 
 std::shared_ptr<image::decoded>
-    depthmap::transformer::transform(std::shared_ptr<augment::image::params>  img_xform,
-                                     std::shared_ptr<image::decoded> image_list)
+    depthmap::transformer::transform(std::shared_ptr<augment::image::params> img_xform,
+                                     std::shared_ptr<image::decoded>         image_list)
 {
     if (image_list->get_image_count() != 1)
         throw invalid_argument("depthmap transform only supports a single image");

--- a/src/etl_depthmap.hpp
+++ b/src/etl_depthmap.hpp
@@ -47,13 +47,14 @@ private:
 // Transform
 //-------------------------------------------------------------------------
 
-class nervana::depthmap::transformer : public interface::transformer<image::decoded, augment::image::params>
+class nervana::depthmap::transformer
+    : public interface::transformer<image::decoded, augment::image::params>
 {
 public:
     transformer(const image::config&);
     ~transformer();
-    std::shared_ptr<image::decoded> transform(std::shared_ptr<augment::image::params>  txs,
-                                              std::shared_ptr<image::decoded> mp) override;
+    std::shared_ptr<image::decoded> transform(std::shared_ptr<augment::image::params> txs,
+                                              std::shared_ptr<image::decoded>         mp) override;
 };
 
 //-------------------------------------------------------------------------

--- a/src/etl_image.cpp
+++ b/src/etl_image.cpp
@@ -104,8 +104,9 @@ image::transformer::transformer(const image::config&)
 {
 }
 
-shared_ptr<image::decoded> image::transformer::transform(shared_ptr<augment::image::params>  img_xform,
-                                                         shared_ptr<image::decoded> img)
+shared_ptr<image::decoded>
+    image::transformer::transform(shared_ptr<augment::image::params> img_xform,
+                                  shared_ptr<image::decoded>         img)
 {
     vector<cv::Mat> finalImageList;
     for (int i = 0; i < img->get_image_count(); i++)
@@ -122,7 +123,7 @@ shared_ptr<image::decoded> image::transformer::transform(shared_ptr<augment::ima
 }
 
 cv::Mat image::transformer::transform_single_image(shared_ptr<augment::image::params> img_xform,
-                                                   cv::Mat&                  single_img)
+                                                   cv::Mat&                           single_img)
 {
     // img_xform->dump(cout);
     cv::Mat rotatedImage;

--- a/src/etl_image.hpp
+++ b/src/etl_image.hpp
@@ -62,8 +62,8 @@ public:
     uint32_t    width;
     std::string output_type{"uint8_t"};
 
-    bool     channel_major        = true;
-    uint32_t channels             = 3;
+    bool     channel_major = true;
+    uint32_t channels      = 3;
 
     std::string name;
 
@@ -73,21 +73,18 @@ public:
     {
         return config_list;
     }
-   
-    config() {}
 
+    config() {}
 private:
-    std::vector<std::shared_ptr<interface::config_info_interface>> config_list =
-    {
+    std::vector<std::shared_ptr<interface::config_info_interface>> config_list = {
         ADD_SCALAR(height, mode::REQUIRED),
         ADD_SCALAR(width, mode::REQUIRED),
         ADD_SCALAR(name, mode::OPTIONAL),
         ADD_SCALAR(channel_major, mode::OPTIONAL),
         ADD_SCALAR(channels, mode::OPTIONAL, [](uint32_t v) { return v == 1 || v == 3; }),
-        ADD_SCALAR(output_type,
-                   mode::OPTIONAL,
-                   [](const std::string& v) { return output_type::is_valid_type(v); })
-    };
+        ADD_SCALAR(output_type, mode::OPTIONAL, [](const std::string& v) {
+            return output_type::is_valid_type(v);
+        })};
 
     void validate();
 
@@ -126,11 +123,7 @@ public:
     {
         return get_image_size().area() * get_image_channels() * get_image_count();
     }
-    cv::Size2i image_size() const override
-    {
-        return _images[0].size();
-    }
-
+    cv::Size2i image_size() const override { return _images[0].size(); }
 protected:
     bool all_images_are_same_size()
     {
@@ -157,7 +150,8 @@ private:
     int _color_mode;
 };
 
-class nervana::image::transformer : public interface::transformer<image::decoded, augment::image::params>
+class nervana::image::transformer
+    : public interface::transformer<image::decoded, augment::image::params>
 {
 public:
     transformer(const image::config&);

--- a/src/etl_label_map.hpp
+++ b/src/etl_label_map.hpp
@@ -48,7 +48,7 @@ public:
     std::string              output_type = "uint32_t";
     std::vector<std::string> class_names;
     int                      max_classes = 100;
-    std::string name;
+    std::string              name;
 
     config(nlohmann::json js);
     virtual ~config() {}

--- a/src/etl_localization.cpp
+++ b/src/etl_localization.cpp
@@ -94,7 +94,7 @@ localization::transformer::transformer(const localization::config& _cfg, float f
 
 shared_ptr<localization::decoded>
     localization::transformer::transform(shared_ptr<augment::image::params> settings,
-                                         shared_ptr<localization::decoded> mp)
+                                         shared_ptr<localization::decoded>  mp)
 {
     cv::Size input_size = settings->cropbox.size();
     float    im_scale;

--- a/src/etl_localization.hpp
+++ b/src/etl_localization.hpp
@@ -106,7 +106,7 @@ public:
     float  foreground_fraction = 0.5; // at most, positive anchors are 0.5 of the total rois
     size_t max_gt_boxes        = 64;
     std::vector<std::string> class_names;
-    std::string name;
+    std::string              name;
 
     // Derived values
     size_t output_buffer_size;
@@ -185,8 +185,8 @@ public:
 
     virtual ~transformer() {}
     std::shared_ptr<localization::decoded>
-        transform(std::shared_ptr<augment::image::params>         txs,
-                  std::shared_ptr<localization::decoded> mp) override;
+        transform(std::shared_ptr<augment::image::params> txs,
+                  std::shared_ptr<localization::decoded>  mp) override;
 
 private:
     transformer() = delete;

--- a/src/etl_multicrop.cpp
+++ b/src/etl_multicrop.cpp
@@ -50,7 +50,7 @@ multicrop::config::config(nlohmann::json js)
     INFO;
     // shape is going to be different from crop_config because of multiple images
     shape_t multicrop_shape = crop_config.get_shape_type().get_shape();
-    auto axes_names = crop_config.get_shape_type().get_names();
+    auto    axes_names      = crop_config.get_shape_type().get_names();
     axes_names.insert(axes_names.begin(), "views");
 
     uint32_t num_views = crop_count * crop_scales.size() * (crop_config.flip_enable ? 2 : 1);
@@ -93,8 +93,8 @@ multicrop::transformer::transformer(const multicrop::config& cfg)
 }
 
 shared_ptr<image::decoded>
-    multicrop::transformer::transform(shared_ptr<augment::image::params>  crop_settings,
-                                      shared_ptr<image::decoded> input)
+    multicrop::transformer::transform(shared_ptr<augment::image::params> crop_settings,
+                                      shared_ptr<image::decoded>         input)
 {
     cv::Size2i in_size      = input->get_image_size();
     auto       cropbox_size = image::cropbox_max_proportional(in_size, crop_settings->output_size);

--- a/src/etl_multicrop.hpp
+++ b/src/etl_multicrop.hpp
@@ -37,7 +37,7 @@ public:
     // Required config variables
     std::vector<float>     crop_scales;
     nervana::image::config crop_config;
-    std::string name;
+    std::string            name;
 
     // Optional config variables
     int crop_count = 5;
@@ -60,7 +60,8 @@ private:
     void validate();
 };
 
-class nervana::multicrop::transformer : public interface::transformer<image::decoded, augment::image::params>
+class nervana::multicrop::transformer
+    : public interface::transformer<image::decoded, augment::image::params>
 {
 public:
     transformer(const multicrop::config& cfg);

--- a/src/etl_pixel_mask.cpp
+++ b/src/etl_pixel_mask.cpp
@@ -58,8 +58,8 @@ pixel_mask::transformer::~transformer()
 }
 
 std::shared_ptr<image::decoded>
-    pixel_mask::transformer::transform(std::shared_ptr<augment::image::params>  img_xform,
-                                       std::shared_ptr<image::decoded> image_list)
+    pixel_mask::transformer::transform(std::shared_ptr<augment::image::params> img_xform,
+                                       std::shared_ptr<image::decoded>         image_list)
 {
     if (image_list->get_image_count() != 1)
         throw invalid_argument("pixel_mask transform only supports a single image");

--- a/src/etl_pixel_mask.hpp
+++ b/src/etl_pixel_mask.hpp
@@ -53,8 +53,8 @@ class nervana::pixel_mask::transformer
 public:
     transformer(const image::config&);
     ~transformer();
-    std::shared_ptr<image::decoded> transform(std::shared_ptr<augment::image::params>  txs,
-                                              std::shared_ptr<image::decoded> mp) override;
+    std::shared_ptr<image::decoded> transform(std::shared_ptr<augment::image::params> txs,
+                                              std::shared_ptr<image::decoded>         mp) override;
 };
 
 //-------------------------------------------------------------------------

--- a/src/etl_video.cpp
+++ b/src/etl_video.cpp
@@ -46,8 +46,8 @@ video::transformer::transformer(const video::config& config)
 }
 
 std::shared_ptr<image::decoded>
-    video::transformer::transform(std::shared_ptr<augment::image::params>  img_xform,
-                                  std::shared_ptr<image::decoded> img)
+    video::transformer::transform(std::shared_ptr<augment::image::params> img_xform,
+                                  std::shared_ptr<image::decoded>         img)
 {
     auto tx_img  = frame_transformer.transform(img_xform, img);
     auto out_img = make_shared<image::decoded>();

--- a/src/etl_video.hpp
+++ b/src/etl_video.hpp
@@ -34,7 +34,7 @@ class nervana::video::config : public interface::config
 public:
     uint32_t               max_frame_count;
     nervana::image::config frame;
-    std::string name;
+    std::string            name;
 
     config(nlohmann::json js)
         : frame(js["frame"])
@@ -77,7 +77,8 @@ private:
 };
 
 // simple wrapper around image::transformer for now
-class nervana::video::transformer : public interface::transformer<image::decoded, augment::image::params>
+class nervana::video::transformer
+    : public interface::transformer<image::decoded, augment::image::params>
 {
 public:
     transformer(const video::config&);

--- a/src/image.cpp
+++ b/src/image.cpp
@@ -226,10 +226,10 @@ void image::photometric::cbsjitter(
         *  BRIGHTNESS & SATURATION  *
         *****************************/
         // float data[] = {0.114, 0.587, 0.299};   // NTSC
-        float data[] = {0.0820, 0.6094, 0.3086};
-        const cv::Mat GSCL(3, 1, CV_32FC1, data); 
-        cv::Mat satmtx = brightness * (saturation * cv::Mat::eye(3, 3, CV_32FC1) +
-                                (1 - saturation) * cv::Mat::ones(3, 1, CV_32FC1) * GSCL.t());
+        float         data[] = {0.0820, 0.6094, 0.3086};
+        const cv::Mat GSCL(3, 1, CV_32FC1, data);
+        cv::Mat       satmtx = brightness * (saturation * cv::Mat::eye(3, 3, CV_32FC1) +
+                                       (1 - saturation) * cv::Mat::ones(3, 1, CV_32FC1) * GSCL.t());
         cv::transform(inout, inout, satmtx);
     }
 
@@ -250,7 +250,7 @@ void image::photometric::cbsjitter(
 //     /****************************
 //     *  BRIGHTNESS & SATURATION  *
 //     *****************************/
-    
+
 //     const cv::Mat GSCL(3, 1, CV_32FC1, {0.114, 0.587, 0.299});
 //     cv::Mat satmtx = brightness * (saturation * cv::Mat::eye(3, 3, CV_32FC1) +
 //                             (1 - saturation) * cv::Mat::ones(3, 1, CV_32FC1) * GSCL.t());

--- a/src/image.hpp
+++ b/src/image.hpp
@@ -51,8 +51,10 @@ namespace nervana
             static void lighting(cv::Mat& inout, std::vector<float>, float color_noise_std);
             static void cbsjitter(
                 cv::Mat& inout, float contrast, float brightness, float saturation, int hue = 0);
-            static void transform_hsv(
-                cv::Mat& image, const float h_gain, const float s_gain, const float v_gain );
+            static void transform_hsv(cv::Mat&    image,
+                                      const float h_gain,
+                                      const float s_gain,
+                                      const float v_gain);
 
             // These are the eigenvectors of the pixelwise covariance matrix
             static const float   _CPCA[3][3];

--- a/src/interface.cpp
+++ b/src/interface.cpp
@@ -65,7 +65,7 @@ void json_configurable::verify_config(
                 }
                 stringstream ss;
                 ss << "key '" << key << "' not found";
-                if (distance < key.size()/2)
+                if (distance < key.size() / 2)
                 {
                     ss << ", did you mean '" << suggestion << "'";
                 }

--- a/src/interface.hpp
+++ b/src/interface.hpp
@@ -110,7 +110,6 @@ public:
     std::make_shared<nervana::interface::config_info<decltype(var)>>(                              \
         var, #var, mode, parse_object<decltype(var)>, ##__VA_ARGS__)
 
-
     template <typename T, typename S>
     static void set_dist_params(T& dist, S& params)
     {
@@ -155,16 +154,16 @@ public:
     }
 
     template <typename T>
-    static void parse_object(T&                   value,
-                            const std::string&    key,
-                            const nlohmann::json& js,
-                            mode                  required = mode::OPTIONAL)
+    static void parse_object(T&                    value,
+                             const std::string&    key,
+                             const nlohmann::json& js,
+                             mode                  required = mode::OPTIONAL)
     {
         auto val = js.find(key);
         if (val != js.end())
         {
             auto obj = js[key];
-            value = obj.get<std::vector<nlohmann::json>>();
+            value    = obj.get<std::vector<nlohmann::json>>();
         }
         else if (required == mode::REQUIRED)
         {
@@ -211,9 +210,10 @@ public:
                         const std::string&         output_type_,
                         const bool                 flatten_all_dims_ = false)
     {
-        m_shape_type_list.emplace_back(shape_, nervana::output_type{output_type_}, flatten_all_dims_);
+        m_shape_type_list.emplace_back(
+            shape_, nervana::output_type{output_type_}, flatten_all_dims_);
     }
-    
+
     void add_shape_type(const std::vector<size_t>&  shape_,
                         const nervana::output_type& output_type_,
                         const bool                  flatten_all_dims_ = false)
@@ -221,15 +221,14 @@ public:
         m_shape_type_list.emplace_back(shape_, output_type_, flatten_all_dims_);
     }
 
-    void add_shape_type(const std::vector<size_t>&  shape_,
-                        const std::vector<std::string>&  names_,
-                        const nervana::output_type& output_type_,
-                        const bool                  flatten_all_dims_ = false)
+    void add_shape_type(const std::vector<size_t>&      shape_,
+                        const std::vector<std::string>& names_,
+                        const nervana::output_type&     output_type_,
+                        const bool                      flatten_all_dims_ = false)
     {
         m_shape_type_list.emplace_back(shape_, output_type_, flatten_all_dims_);
         m_shape_type_list.back().set_names(names_);
     }
-
 
 private:
     std::vector<nervana::shape_type> m_shape_type_list;
@@ -281,10 +280,7 @@ public:
     {
     }
 
-    virtual ~config_info()
-    {
-    }
-
+    virtual ~config_info() {}
     const std::string& name() const override { return m_variable_name; }
     bool required() const override { return m_parse_mode == interface::config::mode::REQUIRED; }
     std::string type() const override { return type_name<T>(); }

--- a/src/loader.cpp
+++ b/src/loader.cpp
@@ -94,8 +94,8 @@ loader::~loader()
 
 void loader::initialize(nlohmann::json& config_json)
 {
-    string        config_string = config_json.dump();
-    m_current_config = config_json;
+    string config_string = config_json.dump();
+    m_current_config     = config_json;
     loader_config lcfg(config_json);
     m_batch_size = lcfg.batch_size;
 
@@ -115,11 +115,11 @@ void loader::initialize(nlohmann::json& config_json)
     m_batch_count_value = (m_manifest->record_count() + m_batch_size - 1) / m_batch_size;
     if (lcfg.iteration_mode == "ONCE")
     {
-        m_batch_mode        = BatchMode::ONCE;
+        m_batch_mode = BatchMode::ONCE;
     }
     else if (lcfg.iteration_mode == "INFINITE")
     {
-        m_batch_mode        = BatchMode::INFINITE;
+        m_batch_mode = BatchMode::INFINITE;
     }
     else if (lcfg.iteration_mode == "COUNT")
     {

--- a/src/loader.hpp
+++ b/src/loader.hpp
@@ -51,16 +51,16 @@ public:
     std::string manifest_root;
     int         batch_size;
 
-    std::string cache_directory      = "";
-    int         block_size           = 0;
-    float       subset_fraction      = 1.0;
-    bool        shuffle_enable       = false;
-    bool        shuffle_manifest     = false;
-    bool        single_thread        = false;
-    bool        pinned               = false;
-    int         random_seed          = 0;
-    std::string iteration_mode       = "ONCE";
-    int         iteration_mode_count = 0;
+    std::string                 cache_directory      = "";
+    int                         block_size           = 0;
+    float                       subset_fraction      = 1.0;
+    bool                        shuffle_enable       = false;
+    bool                        shuffle_manifest     = false;
+    bool                        single_thread        = false;
+    bool                        pinned               = false;
+    int                         random_seed          = 0;
+    std::string                 iteration_mode       = "ONCE";
+    int                         iteration_mode_count = 0;
     std::vector<nlohmann::json> etl;
     std::vector<nlohmann::json> augmentation;
 
@@ -111,7 +111,6 @@ public:
 
     int record_count() { return m_manifest->record_count(); }
     int batch_size() { return m_batch_size; }
-
     // member typedefs provided through inheriting from std::iterator
     class iterator : public std::iterator<std::input_iterator_tag, // iterator_category
                                           fixed_buffer_map         // value_type
@@ -159,11 +158,7 @@ public:
         m_position          = 0;
     }
 
-    nlohmann::json get_current_config() const
-    {
-        return m_current_config;
-    }
-
+    nlohmann::json get_current_config() const { return m_current_config; }
 private:
     loader() = delete;
     void initialize(nlohmann::json& config_json);

--- a/src/manifest.hpp
+++ b/src/manifest.hpp
@@ -36,7 +36,6 @@ namespace nervana
 
         manifest() {}
         virtual ~manifest() {}
-
         virtual std::string cache_id() = 0;
         virtual std::string version()  = 0;
 

--- a/src/manifest_file.cpp
+++ b/src/manifest_file.cpp
@@ -217,10 +217,10 @@ void manifest_file::initialize(std::istream&      stream,
         {
             for (int i = 0; i < m_element_types.size(); i++)
             {
-
                 if (m_element_types[i] == element_t::FILE)
                 {
-                    record_list[record_number][i] = file_util::path_join(root, record_list[record_number][i]);
+                    record_list[record_number][i] =
+                        file_util::path_join(root, record_list[record_number][i]);
                 }
             }
         }

--- a/src/manifest_file.hpp
+++ b/src/manifest_file.hpp
@@ -69,9 +69,9 @@ public:
     std::vector<std::vector<std::string>>* next() override;
     void                                   reset() override;
 
-    size_t block_count() const { return m_block_list.size(); }
-    size_t record_count() const override { return m_record_count; }
-    size_t elements_per_record() const override { return m_element_types.size(); }
+    size_t   block_count() const { return m_block_list.size(); }
+    size_t   record_count() const override { return m_record_count; }
+    size_t   elements_per_record() const override { return m_element_types.size(); }
     uint32_t get_crc();
 
     static char                   get_delimiter() { return m_delimiter_char; }

--- a/src/provider_custom.hpp
+++ b/src/provider_custom.hpp
@@ -315,6 +315,7 @@ private:
     nervana::char_map::extractor m_extractor;
     nervana::char_map::loader    m_loader;
     const std::string            m_buffer_name;
+    const std::string            m_length_name;
 };
 
 //=================================================================================================

--- a/src/provider_factory.hpp
+++ b/src/provider_factory.hpp
@@ -50,6 +50,5 @@ public:
 
 private:
     std::vector<std::shared_ptr<nervana::interface::config_info_interface>> config_list = {
-        ADD_OBJECT(etl, mode::REQUIRED),
-        ADD_OBJECT(augmentation, mode::OPTIONAL)};
+        ADD_OBJECT(etl, mode::REQUIRED), ADD_OBJECT(augmentation, mode::OPTIONAL)};
 };

--- a/src/provider_interface.hpp
+++ b/src/provider_interface.hpp
@@ -39,7 +39,6 @@ public:
     }
 
     virtual ~provider_interface() {}
-
     virtual void provide(int                           idx,
                          nervana::encoded_record_list& in_buf,
                          nervana::fixed_buffer_map&    out_buf) = 0;

--- a/src/raw_image.cpp
+++ b/src/raw_image.cpp
@@ -62,7 +62,7 @@ void raw_image::read(istream& f)
         auto tokens = split(line, ':', true);
         if (tokens.size() == 2)
         {
-            string tag = tokens[0];
+            string tag   = tokens[0];
             string value = tokens[1];
             if (tag == "width")
             {
@@ -126,15 +126,15 @@ raw_image raw_image::from_cvmat(cv::Mat& mat)
     rc.m_bitwidth = mat.elemSize1() * 8;
 
     size_t size = rc.m_width * rc.m_height * rc.m_channels * (rc.m_bitwidth / 8);
-    rc.m_data = shared_ptr<char>(new char[size], std::default_delete<char[]>());
+    rc.m_data   = shared_ptr<char>(new char[size], std::default_delete<char[]>());
     memcpy(&*rc.m_data, mat.data, size);
 
     return rc;
 }
 
-cv::Mat   raw_image::to_cvmat()
+cv::Mat raw_image::to_cvmat()
 {
-    int     type = 0;
+    int type = 0;
 
     if (m_is_float)
     {
@@ -149,7 +149,7 @@ cv::Mat   raw_image::to_cvmat()
     {
         switch (m_bitwidth)
         {
-        case 8: type = CV_MAKETYPE(CV_8U, m_channels); break;
+        case 8: type  = CV_MAKETYPE(CV_8U, m_channels); break;
         case 16: type = CV_MAKETYPE(CV_16U, m_channels); break;
         default: break;
         }

--- a/src/raw_image.hpp
+++ b/src/raw_image.hpp
@@ -36,7 +36,7 @@ public:
     void write(std::ostream& out_stream);
 
     static raw_image from_cvmat(cv::Mat&);
-    cv::Mat   to_cvmat();
+    cv::Mat          to_cvmat();
 
     size_t size() const;
 

--- a/src/typemap.hpp
+++ b/src/typemap.hpp
@@ -102,12 +102,12 @@ public:
     const std::vector<size_t>& get_shape() const { return m_shape; }
     const output_type&         get_otype() const { return m_otype; }
     bool                       flatten_all_dims() const { return m_flatten_with_batch_size; }
-
     void set_names(const std::vector<std::string>& names)
     {
         if (m_shape.size() != names.size())
         {
-            throw std::runtime_error("naming shape dimensions: number of names does not match number of dimensions");
+            throw std::runtime_error(
+                "naming shape dimensions: number of names does not match number of dimensions");
         }
         else
         {
@@ -120,7 +120,7 @@ public:
         if (m_names.size() == 0)
         {
             std::vector<std::string> res;
-            for (int i=0; i < m_shape.size(); ++i)
+            for (int i = 0; i < m_shape.size(); ++i)
             {
                 res.push_back(std::to_string(i));
             }
@@ -133,9 +133,9 @@ public:
     }
 
 private:
-    std::vector<size_t> m_shape;
-    output_type         m_otype;
-    size_t              m_byte_size;
-    bool                m_flatten_with_batch_size;
+    std::vector<size_t>      m_shape;
+    output_type              m_otype;
+    size_t                   m_byte_size;
+    bool                     m_flatten_with_batch_size;
     std::vector<std::string> m_names;
 };

--- a/src/util.hpp
+++ b/src/util.hpp
@@ -46,7 +46,7 @@ namespace nervana
     {
         const char* data  = (const char*)_data;
         T           value = 0;
-        char* v     = (char*)&value;
+        char*       v     = (char*)&value;
         for (size_t i = 0; i < sizeof(T); i++)
         {
             v[i] = data[offset + BYTEIDX(i, sizeof(T), e)];
@@ -57,8 +57,8 @@ namespace nervana
     template <typename T>
     void pack(void* _data, T value, size_t offset = 0, endian e = endian::LITTLE)
     {
-        char* data  = (char*)_data;
-        char* v = (char*)&value;
+        char* data = (char*)_data;
+        char* v    = (char*)&value;
         for (size_t i = 0; i < sizeof(T); i++)
         {
             data[offset + i] = v[BYTEIDX(i, sizeof(T), e)];
@@ -173,38 +173,22 @@ namespace nervana
                 m_start_time = m_clock.now();
             }
         }
-        
+
         void stop()
         {
             if (m_active == true)
             {
                 auto end_time = m_clock.now();
-                m_last_time = end_time - m_start_time;
+                m_last_time   = end_time - m_start_time;
                 m_total_time += m_last_time;
                 m_active = false;
             }
         }
 
-        size_t get_call_count() const
-        {
-            return m_total_count;
-        }
-
-        size_t get_seconds() const
-        {
-            return get_nanoseconds() / 1e9;
-        }
-
-        size_t get_milliseconds() const
-        {
-            return get_nanoseconds() / 1e6;
-        }
-
-        size_t get_microseconds() const
-        {
-            return get_nanoseconds() / 1e3;
-        }
-
+        size_t get_call_count() const { return m_total_count; }
+        size_t get_seconds() const { return get_nanoseconds() / 1e9; }
+        size_t get_milliseconds() const { return get_nanoseconds() / 1e6; }
+        size_t get_microseconds() const { return get_nanoseconds() / 1e3; }
         size_t get_nanoseconds() const
         {
             if (m_active)
@@ -213,37 +197,22 @@ namespace nervana
             }
             else
             {
-                return m_last_time.count();                
+                return m_last_time.count();
             }
         }
 
-        size_t get_total_seconds() const
-        {
-            return get_total_nanoseconds() / 1e9;
-        }
-
-        size_t get_total_milliseconds() const
-        {
-            return get_total_nanoseconds() / 1e6;
-        }
-
-        size_t get_total_microseconds() const
-        {
-            return get_total_nanoseconds() / 1e3;
-        }
-
-        size_t get_total_nanoseconds() const
-        {
-            return m_total_time.count();
-        }
-
+        size_t get_total_seconds() const { return get_total_nanoseconds() / 1e9; }
+        size_t get_total_milliseconds() const { return get_total_nanoseconds() / 1e6; }
+        size_t get_total_microseconds() const { return get_total_nanoseconds() / 1e3; }
+        size_t get_total_nanoseconds() const { return m_total_time.count(); }
     private:
         std::chrono::high_resolution_clock                          m_clock;
         std::chrono::time_point<std::chrono::high_resolution_clock> m_start_time;
         bool                                                        m_active = false;
-        std::chrono::nanoseconds                                    m_total_time = std::chrono::high_resolution_clock::duration::zero();
-        std::chrono::nanoseconds                                    m_last_time;
-        size_t                                                      m_total_count = 0;
-        std::string                                                 m_name;
+        std::chrono::nanoseconds                                    m_total_time =
+            std::chrono::high_resolution_clock::duration::zero();
+        std::chrono::nanoseconds m_last_time;
+        size_t                   m_total_count = 0;
+        std::string              m_name;
     };
 }

--- a/src/web_app.cpp
+++ b/src/web_app.cpp
@@ -156,10 +156,11 @@ void web_app::loader(web::page& p)
             out << "<div class=\"container\">";
             for (size_t i = 0; i < image_buffer.get_item_count(); i++)
             {
-                cv::Mat mat = image_buffer.get_item_as_mat(i);
+                cv::Mat         mat = image_buffer.get_item_as_mat(i);
                 vector<uint8_t> encoded;
                 imencode(".jpg", mat, encoded);
-                vector<char> b64 = nervana::base64::encode((const char*)encoded.data(), encoded.size());
+                vector<char> b64 =
+                    nervana::base64::encode((const char*)encoded.data(), encoded.size());
                 out << "\n<img src=\"data:image/jpg;base64,";
                 p.raw_send(b64.data(), b64.size());
                 out << "\" style=\"padding-top:5px\"";

--- a/src/web_app.hpp
+++ b/src/web_app.hpp
@@ -35,8 +35,8 @@ public:
     void deregister_loader(const nervana::loader*);
 
 private:
-    web::server web_server;
-    std::vector<nervana::loader*>     m_loader_list; 
+    web::server                   web_server;
+    std::vector<nervana::loader*> m_loader_list;
 };
 
 extern web_app debug_web_app;

--- a/test/dataset.hpp
+++ b/test/dataset.hpp
@@ -40,7 +40,6 @@ public:
     }
 
     virtual ~dataset() {}
-
     T& directory(const std::string& dir)
     {
         m_path = dir;

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -163,16 +163,15 @@ extern "C" int main(int argc, char** argv)
     cout << "OpenCV version : " << CV_VERSION << endl;
     mock_nds_server server;
 
-    const char* exclude = "--gtest_filter=-benchmark.*";
+    const char*   exclude = "--gtest_filter=-benchmark.*";
     vector<char*> argv_vector;
     argv_vector.push_back(argv[0]);
     argv_vector.push_back((char*)exclude);
-    for (int i=1; i<argc; i++)
+    for (int i = 1; i < argc; i++)
     {
         argv_vector.push_back(argv[i]);
     }
     argc++;
-
 
     CreateImageDataset();
     test_cache_directory = nervana::file_util::make_temp_directory();

--- a/test/test_audio.cpp
+++ b/test/test_audio.cpp
@@ -45,9 +45,9 @@ TEST(wav, compare)
     bool     all_eq      = true;
     for (int i = 0; i < num_samples; i++)
     {
-        size_t   offset = i * sizeof(int16_t);
+        size_t  offset = i * sizeof(int16_t);
         int16_t waddr  = unpack<int16_t>(wav.get_raw_data()[0] + offset);
-        int16_t  dval   = extracted_wav.at<int16_t>(i, 0);
+        int16_t dval   = extracted_wav.at<int16_t>(i, 0);
         if (waddr != dval)
         {
             all_eq = false;
@@ -100,7 +100,7 @@ TEST(audio, specgram)
 
 TEST(audio, transform)
 {
-    auto js = R"(
+    auto js     = R"(
         {
             "max_duration": "2000 milliseconds",
             "frame_length": "1024 samples",
@@ -130,8 +130,8 @@ TEST(audio, transform)
 
     audio::config config(js);
 
-    audio::extractor     extractor;
-    audio::transformer   _audioTransformer(config);
+    audio::extractor              extractor;
+    audio::transformer            _audioTransformer(config);
     augment::audio::param_factory factory(js_aug);
 
     auto decoded_audio = extractor.extract(databuf, bufsize);
@@ -169,7 +169,7 @@ TEST(wav, read)
 
 TEST(audio, transform2)
 {
-    auto js = R"(
+    auto js     = R"(
         {
             "max_duration": "3 seconds",
             "frame_length": "256 samples",
@@ -197,8 +197,8 @@ TEST(audio, transform2)
 
     audio::config config(js);
 
-    audio::extractor     extractor;
-    audio::transformer   _audioTransformer(config);
+    audio::extractor              extractor;
+    audio::transformer            _audioTransformer(config);
     augment::audio::param_factory factory(js_aug);
 
     auto decoded_audio = extractor.extract(databuf, bufsize);
@@ -214,7 +214,7 @@ TEST(audio, transform2)
 
 TEST(audio, samples_out)
 {
-    auto js = R"(
+    auto js     = R"(
         {
             "feature_type": "samples",
             "output_type": "int16_t",
@@ -245,12 +245,12 @@ TEST(audio, samples_out)
 
     audio::config config(js);
 
-    audio::extractor     extractor;
-    audio::transformer   _audioTransformer(config);
-    audio::loader        _audioLoader(config);
+    audio::extractor              extractor;
+    audio::transformer            _audioTransformer(config);
+    audio::loader                 _audioLoader(config);
     augment::audio::param_factory factory(js_aug);
-    auto                 decoded_audio = extractor.extract(databuf, bufsize);
-    auto                 audioParams   = factory.make_params();
+    auto                          decoded_audio = extractor.extract(databuf, bufsize);
+    auto                          audioParams   = factory.make_params();
 
     cv::Mat output_samples(1, config.max_duration_tn, CV_16SC1);
     auto    xformed_audio = _audioTransformer.transform(audioParams, decoded_audio);
@@ -267,7 +267,7 @@ TEST(audio, samples_out)
 
     for (int i = 0; i < wav_samples; i++)
     {
-        size_t   offset = i * sizeof(int16_t);
+        size_t  offset = i * sizeof(int16_t);
         int16_t waddr  = unpack<int16_t>(wav.get_raw_data()[0] + offset);
         if (waddr != output_samples.at<int16_t>(0, i))
         {

--- a/test/test_augmentation.cpp
+++ b/test/test_augmentation.cpp
@@ -59,4 +59,3 @@ TEST(image_augmentation, config)
 
     EXPECT_FLOAT_EQ(0.0, config.flip_distribution.p());
 }
-

--- a/test/test_bbox.cpp
+++ b/test/test_bbox.cpp
@@ -101,8 +101,8 @@ cv::Mat
 shared_ptr<augment::image::params> make_params(int width, int height)
 {
     shared_ptr<augment::image::params> iparam = make_shared<augment::image::params>();
-    iparam->cropbox                  = cv::Rect(0, 0, width, height);
-    iparam->output_size              = cv::Size(width, height);
+    iparam->cropbox                           = cv::Rect(0, 0, width, height);
+    iparam->output_size                       = cv::Size(width, height);
     return iparam;
 }
 
@@ -203,9 +203,9 @@ TEST(boundingbox, bbox)
     EXPECT_EQ(8, boxes[1].label);
     EXPECT_EQ(7, boxes[2].label);
 
-    boundingbox::transformer  transform(cfg);
+    boundingbox::transformer           transform(cfg);
     shared_ptr<augment::image::params> iparam = make_params(256, 256);
-    auto                      tx     = transform.transform(iparam, decoded);
+    auto                               tx     = transform.transform(iparam, decoded);
 }
 
 TEST(boundingbox, crop)
@@ -240,9 +240,9 @@ TEST(boundingbox, crop)
 
     ASSERT_EQ(8, boxes.size());
 
-    boundingbox::transformer  transform(cfg);
+    boundingbox::transformer           transform(cfg);
     shared_ptr<augment::image::params> iparam = make_params(256, 256);
-    iparam->cropbox                  = cv::Rect(35, 35, 40, 40);
+    iparam->cropbox                           = cv::Rect(35, 35, 40, 40);
 
     auto d = draw(256, 256, decoded->boxes(), iparam->cropbox);
     cv::imwrite("bbox_crop.png", d);
@@ -297,13 +297,13 @@ TEST(boundingbox, rescale)
 
     ASSERT_EQ(8, boxes.size());
 
-    boundingbox::transformer  transform(cfg);
-    shared_ptr<augment::image::params> iparam    = make_params(256, 256);
-    iparam->output_size                 = cv::Size(512, 1024);
-    auto                     tx_decoded = transform.transform(iparam, decoded);
-    vector<boundingbox::box> tx_boxes   = tx_decoded->boxes();
-    float                    xscale     = 512. / 256.;
-    float                    yscale     = 1024. / 256.;
+    boundingbox::transformer           transform(cfg);
+    shared_ptr<augment::image::params> iparam = make_params(256, 256);
+    iparam->output_size                       = cv::Size(512, 1024);
+    auto                     tx_decoded       = transform.transform(iparam, decoded);
+    vector<boundingbox::box> tx_boxes         = tx_decoded->boxes();
+    float                    xscale           = 512. / 256.;
+    float                    yscale           = 1024. / 256.;
     ASSERT_EQ(8, tx_boxes.size());
     EXPECT_EQ(cv::Rect(10 * xscale, 10 * yscale, 10 * xscale, 10 * yscale), tx_boxes[0].rect());
     EXPECT_EQ(cv::Rect(30 * xscale, 30 * yscale, 10 * xscale, 10 * yscale), tx_boxes[1].rect());
@@ -346,11 +346,11 @@ TEST(boundingbox, flip)
 
     ASSERT_EQ(8, boxes.size());
 
-    boundingbox::transformer  transform(cfg);
-    shared_ptr<augment::image::params> iparam    = make_params(256, 256);
-    iparam->flip                        = 1;
-    auto                     tx_decoded = transform.transform(iparam, decoded);
-    vector<boundingbox::box> tx_boxes   = tx_decoded->boxes();
+    boundingbox::transformer           transform(cfg);
+    shared_ptr<augment::image::params> iparam = make_params(256, 256);
+    iparam->flip                              = 1;
+    auto                     tx_decoded       = transform.transform(iparam, decoded);
+    vector<boundingbox::box> tx_boxes         = tx_decoded->boxes();
     ASSERT_EQ(8, tx_boxes.size());
 
     EXPECT_EQ(cv::Rect(256 - 10 - 10 - 1, 10, 10, 10), tx_boxes[0].rect());
@@ -394,13 +394,13 @@ TEST(boundingbox, crop_flip)
 
     ASSERT_EQ(8, boxes.size());
 
-    boundingbox::transformer  transform(cfg);
-    shared_ptr<augment::image::params> iparam    = make_params(256, 256);
-    iparam->cropbox                     = cv::Rect(35, 35, 40, 40);
-    iparam->output_size                 = cv::Size(256, 256);
-    iparam->flip                        = 1;
-    auto                     tx_decoded = transform.transform(iparam, decoded);
-    vector<boundingbox::box> tx_boxes   = tx_decoded->boxes();
+    boundingbox::transformer           transform(cfg);
+    shared_ptr<augment::image::params> iparam = make_params(256, 256);
+    iparam->cropbox                           = cv::Rect(35, 35, 40, 40);
+    iparam->output_size                       = cv::Size(256, 256);
+    iparam->flip                              = 1;
+    auto                     tx_decoded       = transform.transform(iparam, decoded);
+    vector<boundingbox::box> tx_boxes         = tx_decoded->boxes();
     ASSERT_EQ(6, tx_boxes.size());
 
     float xscale = 256. / 40.;
@@ -430,10 +430,10 @@ TEST(boundingbox, angle)
 
     ASSERT_EQ(1, boxes.size());
 
-    boundingbox::transformer  transform(cfg);
+    boundingbox::transformer           transform(cfg);
     shared_ptr<augment::image::params> iparam = make_params(256, 256);
-    iparam->angle                    = 5;
-    auto tx_decoded                  = transform.transform(iparam, decoded);
+    iparam->angle                             = 5;
+    auto tx_decoded                           = transform.transform(iparam, decoded);
     EXPECT_EQ(nullptr, tx_decoded.get());
 }
 

--- a/test/test_config.cpp
+++ b/test/test_config.cpp
@@ -23,23 +23,17 @@ using namespace nervana;
 
 TEST(config, loader)
 {
-    int    height        = 32;
-    int    width         = 32;
+    int height = 32;
+    int width  = 32;
 
     // config is valid
     nlohmann::json image = {{"type", "image"},
-                           {"name", "image1"},
-                           {"height", height},
-                           {"width", width},
-                           {"channel_major", false}};
-    nlohmann::json label = {{"type", "label"},
-                           {"name", "label1"},
-                           {"binary", false}};
-    nlohmann::json js = {
-                         {"manifest_filename", "blah"},
-                         {"batch_size", 1},
-                         {"etl", {image, label}}
-                         };
+                            {"name", "image1"},
+                            {"height", height},
+                            {"width", width},
+                            {"channel_major", false}};
+    nlohmann::json label = {{"type", "label"}, {"name", "label1"}, {"binary", false}};
+    nlohmann::json js = {{"manifest_filename", "blah"}, {"batch_size", 1}, {"etl", {image, label}}};
 
     loader_config cfg{js};
     // EXPECT_NO_THROW(loader_config cfg{js});

--- a/test/test_image.cpp
+++ b/test/test_image.cpp
@@ -178,9 +178,7 @@ TEST(image, missing_config_arg)
 
 TEST(image, config)
 {
-    nlohmann::json js = {{"height", 30},
-                         {"width", 30},
-                         {"channels", 3}};
+    nlohmann::json js = {{"height", 30}, {"width", 30}, {"channels", 3}};
 
     image::config config(js);
     EXPECT_EQ(30, config.height);
@@ -247,9 +245,11 @@ TEST(image, transform_crop)
 
     augment::image::param_factory factory(aug);
 
-    auto image_size = decoded->get_image_size();
-    image_params_builder      builder(factory.make_params(image_size.width, image_size.height, cfg.width, cfg.height));
-    shared_ptr<augment::image::params> params_ptr = builder.cropbox(100, 150, 20, 30).output_size(20, 30);
+    auto                 image_size = decoded->get_image_size();
+    image_params_builder builder(
+        factory.make_params(image_size.width, image_size.height, cfg.width, cfg.height));
+    shared_ptr<augment::image::params> params_ptr =
+        builder.cropbox(100, 150, 20, 30).output_size(20, 30);
 
     image::transformer         trans{cfg};
     shared_ptr<image::decoded> transformed = trans.transform(params_ptr, decoded);
@@ -278,8 +278,9 @@ TEST(image, transform_flip)
 
     augment::image::param_factory factory(aug);
 
-    auto image_size = decoded->get_image_size();
-    image_params_builder      builder(factory.make_params(image_size.width, image_size.height, cfg.width, cfg.height));
+    auto                 image_size = decoded->get_image_size();
+    image_params_builder builder(
+        factory.make_params(image_size.width, image_size.height, cfg.width, cfg.height));
     shared_ptr<augment::image::params> params_ptr =
         builder.cropbox(100, 150, 20, 20).output_size(20, 20).flip(true);
 
@@ -391,14 +392,14 @@ TEST(image, convert_nosplit)
     loader.load({output_image.data}, decoded);
 
     //    cv::imwrite("image_convert_nosplit.png", output_image);
-    int      index = 0;
+    int index = 0;
     for (int row = 0; row < output_image.rows; row++)
     {
         for (int col = 0; col < output_image.cols; col++)
         {
-            ASSERT_EQ(50, unpack<int32_t>(output_image.data, sizeof(int32_t)*index++));  // b
-            ASSERT_EQ(100, unpack<int32_t>(output_image.data, sizeof(int32_t)*index++)); // g
-            ASSERT_EQ(200, unpack<int32_t>(output_image.data, sizeof(int32_t)*index++)); // r
+            ASSERT_EQ(50, unpack<int32_t>(output_image.data, sizeof(int32_t) * index++));  // b
+            ASSERT_EQ(100, unpack<int32_t>(output_image.data, sizeof(int32_t) * index++)); // g
+            ASSERT_EQ(200, unpack<int32_t>(output_image.data, sizeof(int32_t) * index++)); // r
         }
     }
 }
@@ -426,14 +427,15 @@ TEST(image, convert_split)
     loader.load({output_image.data}, decoded);
 
     //    cv::imwrite("image_convert_split.png", output_image);
-    int      index = 0;
+    int index = 0;
     for (int ch = 0; ch < 3; ch++)
     {
         for (int row = 0; row < input_image.rows; row++)
         {
             for (int col = 0; col < input_image.cols; col++)
             {
-                ASSERT_EQ(50 * (ch + 1),  unpack<int32_t>(output_image.data, sizeof(int32_t)*index++));
+                ASSERT_EQ(50 * (ch + 1),
+                          unpack<int32_t>(output_image.data, sizeof(int32_t) * index++));
             }
         }
     }
@@ -453,7 +455,7 @@ TEST(DISABLED_image, multi_crop)
 
     // Just center crop
     {
-        auto                      jsstring = R"(
+        auto           jsstring = R"(
             {
                 "crop_config": {"width": 224,
                                 "height": 224,
@@ -463,13 +465,13 @@ TEST(DISABLED_image, multi_crop)
                 "crop_count": 1
             }
         )";
-        nlohmann::json aug = {{"width", 256}, {"height", 256}};
-        auto                      js       = nlohmann::json::parse(jsstring);
+        nlohmann::json aug      = {{"width", 256}, {"height", 256}};
+        auto           js       = nlohmann::json::parse(jsstring);
         INFO << "\n" << js.dump(4);
         multicrop::config mc_config(js);
         INFO << "\n" << js["crop_config"].dump(4);
-        augment::image::param_factory      factory(js["crop_config"]);
-        auto image_size = decoded->get_image_size();
+        augment::image::param_factory factory(js["crop_config"]);
+        auto                          image_size = decoded->get_image_size();
         INFO << cfg.width;
         INFO << cfg.height;
         INFO << image_size.width;
@@ -506,11 +508,12 @@ TEST(DISABLED_image, multi_crop)
             }
         )";
 
-        auto                      js = nlohmann::json::parse(jsstring);
-        multicrop::config         mc_config(js);
+        auto                               js = nlohmann::json::parse(jsstring);
+        multicrop::config                  mc_config(js);
         augment::image::param_factory      factory(js["crop_config"]);
-        auto image_size = decoded->get_image_size();
-        shared_ptr<augment::image::params> params_ptr = factory.make_params(image_size.width, image_size.height, 224, 224);
+        auto                               image_size = decoded->get_image_size();
+        shared_ptr<augment::image::params> params_ptr =
+            factory.make_params(image_size.width, image_size.height, 224, 224);
 
         multicrop::transformer     trans{mc_config};
         shared_ptr<image::decoded> transformed = trans.transform(params_ptr, decoded);
@@ -544,11 +547,12 @@ TEST(DISABLED_image, multi_crop)
         using namespace cv;
         using idxPt = std::pair<int, Point2i>;
 
-        auto                      js = nlohmann::json::parse(jsstring);
-        multicrop::config         mc_config(js);
+        auto                               js = nlohmann::json::parse(jsstring);
+        multicrop::config                  mc_config(js);
         augment::image::param_factory      factory(js["crop_config"]);
-        auto image_size = decoded->get_image_size();
-        shared_ptr<augment::image::params> params_ptr = factory.make_params(image_size.width, image_size.height, 112, 112);
+        auto                               image_size = decoded->get_image_size();
+        shared_ptr<augment::image::params> params_ptr =
+            factory.make_params(image_size.width, image_size.height, 112, 112);
 
         multicrop::transformer     trans{mc_config};
         shared_ptr<image::decoded> transformed = trans.transform(params_ptr, decoded);
@@ -639,23 +643,20 @@ TEST(image, transform)
         int            height   = 128;
         int            width    = 256;
         int            channels = 3;
-        nlohmann::json js       = {{"height", height},
-                             {"width", width},
-                             {"channels", channels},
-                             {"channel_major", false}};
-        nlohmann::json aug       = {{"type", "image"},
-                             {"flip_enable", false}};
-                             
+        nlohmann::json js       = {
+            {"height", height}, {"width", width}, {"channels", channels}, {"channel_major", false}};
+        nlohmann::json aug = {{"type", "image"}, {"flip_enable", false}};
 
-        image::config        cfg{js};
-        image::extractor     extractor{cfg};
-        image::transformer   transformer{cfg};
-        image::loader        loader{cfg, false};
+        image::config                 cfg{js};
+        image::extractor              extractor{cfg};
+        image::transformer            transformer{cfg};
+        image::loader                 loader{cfg, false};
         augment::image::param_factory factory(aug);
 
-        auto decoded     = extractor.extract(image_data.data(), image_data.size());
+        auto decoded    = extractor.extract(image_data.data(), image_data.size());
         auto image_size = decoded->get_image_size();
-        auto params      = factory.make_params(image_size.width, image_size.height, cfg.width, cfg.height);
+        auto params =
+            factory.make_params(image_size.width, image_size.height, cfg.width, cfg.height);
         auto transformed = transformer.transform(params, decoded);
 
         cv::Mat output_image(height, width, CV_8UC(channels));
@@ -667,24 +668,22 @@ TEST(image, transform)
         int            height   = 128;
         int            width    = 256;
         int            channels = 3;
-        nlohmann::json js       = {{"height", height},
-                             {"width", width},
-                             {"channels", channels},
-                             {"channel_major", false}};
-        nlohmann::json aug       = {{"type", "image"},
-                             {"flip_enable", false}};
+        nlohmann::json js       = {
+            {"height", height}, {"width", width}, {"channels", channels}, {"channel_major", false}};
+        nlohmann::json aug = {{"type", "image"}, {"flip_enable", false}};
 
-        image::config        cfg{js};
-        image::extractor     extractor{cfg};
-        image::transformer   transformer{cfg};
-        image::loader        loader{cfg, false};
+        image::config                 cfg{js};
+        image::extractor              extractor{cfg};
+        image::transformer            transformer{cfg};
+        image::loader                 loader{cfg, false};
         augment::image::param_factory factory(aug);
 
         auto decoded = extractor.extract(image_data.data(), image_data.size());
 
-        auto image_size = decoded->get_image_size();
-        shared_ptr<augment::image::params> params = factory.make_params(image_size.width, image_size.height, cfg.width, cfg.height);
-        params->flip                     = true;
+        auto                               image_size = decoded->get_image_size();
+        shared_ptr<augment::image::params> params =
+            factory.make_params(image_size.width, image_size.height, cfg.width, cfg.height);
+        params->flip = true;
 
         auto transformed = transformer.transform(params, decoded);
 
@@ -697,26 +696,25 @@ TEST(image, transform)
         int            height   = 128;
         int            width    = 256;
         int            channels = 3;
-        nlohmann::json js       = {{"height", height},
-                             {"width", width},
-                             {"channels", channels},
-                             {"channel_major", false}};
-        nlohmann::json aug       = {{"type", "image"},
-                             {"horizontal_distortion", {2, 2}},
-                             {"scale", {0.5, 0.5}},
-                             {"flip_enable", false}};
+        nlohmann::json js       = {
+            {"height", height}, {"width", width}, {"channels", channels}, {"channel_major", false}};
+        nlohmann::json aug = {{"type", "image"},
+                              {"horizontal_distortion", {2, 2}},
+                              {"scale", {0.5, 0.5}},
+                              {"flip_enable", false}};
 
-        image::config        cfg{js};
-        image::extractor     extractor{cfg};
-        image::transformer   transformer{cfg};
-        image::loader        loader{cfg, false};
+        image::config                 cfg{js};
+        image::extractor              extractor{cfg};
+        image::transformer            transformer{cfg};
+        image::loader                 loader{cfg, false};
         augment::image::param_factory factory(aug);
 
         auto decoded = extractor.extract(image_data.data(), image_data.size());
 
-        auto image_size = decoded->get_image_size();
-        shared_ptr<augment::image::params> params = factory.make_params(image_size.width, image_size.height, cfg.width, cfg.height);
-        params->flip                     = false;
+        auto                               image_size = decoded->get_image_size();
+        shared_ptr<augment::image::params> params =
+            factory.make_params(image_size.width, image_size.height, cfg.width, cfg.height);
+        params->flip = false;
 
         auto transformed = transformer.transform(params, decoded);
 
@@ -732,7 +730,7 @@ TEST(image, config_bad_scale)
     int            height   = 128;
     int            width    = 256;
     int            channels = 3;
-    nlohmann::json js       = {{"type", "image"}, 
+    nlohmann::json js       = {{"type", "image"},
                          {"height", height},
                          {"width", width},
                          {"channels", channels},
@@ -755,53 +753,52 @@ TEST(image, area_scale)
         int            height   = 128;
         int            width    = 256;
         int            channels = 3;
-        nlohmann::json js       = {{"height", height},
-                             {"width", width},
-                             {"channels", channels},
-                             {"channel_major", false}};
-        nlohmann::json aug       = {{"type", "image"},
-                             {"do_area_scale", true},
-                             {"flip_enable", false}};
+        nlohmann::json js       = {
+            {"height", height}, {"width", width}, {"channels", channels}, {"channel_major", false}};
+        nlohmann::json aug = {{"type", "image"}, {"do_area_scale", true}, {"flip_enable", false}};
 
         {
-            image::config        cfg{js};
-            image::extractor     extractor{cfg};
+            image::config                 cfg{js};
+            image::extractor              extractor{cfg};
             augment::image::param_factory factory(aug);
 
             auto decoded      = extractor.extract(image_data.data(), image_data.size());
             source_image_area = decoded->get_image_size().area();
 
-            auto image_size = decoded->get_image_size();
-            shared_ptr<augment::image::params> params = factory.make_params(image_size.width, image_size.height, cfg.width, cfg.height);
-            max_cropbox_area                 = params->cropbox.area();
-            max_cropbox_ratio                = max_cropbox_area / source_image_area;
+            auto                               image_size = decoded->get_image_size();
+            shared_ptr<augment::image::params> params =
+                factory.make_params(image_size.width, image_size.height, cfg.width, cfg.height);
+            max_cropbox_area  = params->cropbox.area();
+            max_cropbox_ratio = max_cropbox_area / source_image_area;
         }
         {
             aug["scale"] = {0.3, 0.3};
-            image::config        cfg{js};
-            image::extractor     extractor{cfg};
+            image::config                 cfg{js};
+            image::extractor              extractor{cfg};
             augment::image::param_factory factory(aug);
 
             auto decoded = extractor.extract(image_data.data(), image_data.size());
 
-            auto image_size = decoded->get_image_size();
-            shared_ptr<augment::image::params> params        = factory.make_params(image_size.width, image_size.height, cfg.width, cfg.height);
-            float                     cropbox_area  = params->cropbox.area();
-            float                     cropbox_ratio = cropbox_area / source_image_area;
+            auto                               image_size = decoded->get_image_size();
+            shared_ptr<augment::image::params> params =
+                factory.make_params(image_size.width, image_size.height, cfg.width, cfg.height);
+            float cropbox_area  = params->cropbox.area();
+            float cropbox_ratio = cropbox_area / source_image_area;
             EXPECT_NEAR(0.3, cropbox_ratio, 0.0001);
         }
         {
             aug["scale"] = {0.8, 0.8};
-            image::config        cfg{js};
-            image::extractor     extractor{cfg};
+            image::config                 cfg{js};
+            image::extractor              extractor{cfg};
             augment::image::param_factory factory(aug);
 
             auto decoded = extractor.extract(image_data.data(), image_data.size());
 
-            auto image_size = decoded->get_image_size();
-            shared_ptr<augment::image::params> params        = factory.make_params(image_size.width, image_size.height, cfg.width, cfg.height);
-            float                     cropbox_area  = params->cropbox.area();
-            float                     cropbox_ratio = cropbox_area / source_image_area;
+            auto                               image_size = decoded->get_image_size();
+            shared_ptr<augment::image::params> params =
+                factory.make_params(image_size.width, image_size.height, cfg.width, cfg.height);
+            float cropbox_area  = params->cropbox.area();
+            float cropbox_ratio = cropbox_area / source_image_area;
             EXPECT_FLOAT_EQ(max_cropbox_ratio, cropbox_ratio);
         }
     }
@@ -833,12 +830,8 @@ TEST(image, var_resize)
     vector<unsigned char> img;
     cv::imencode(".png", mat, img);
 
-    nlohmann::json jsConfig = {{"width", 400},
-                               {"height", 400},
-                               {"channels", 3}};
-    nlohmann::json aug       = {{"type", "image"},
-                               {"fixed_aspect_ratio", true},
-                               {"crop_enable", false}};
+    nlohmann::json jsConfig = {{"width", 400}, {"height", 400}, {"channels", 3}};
+    nlohmann::json aug = {{"type", "image"}, {"fixed_aspect_ratio", true}, {"crop_enable", false}};
 
     image::config config_ptr{jsConfig};
 
@@ -852,8 +845,9 @@ TEST(image, var_resize)
     }
 
     augment::image::param_factory      factory(aug);
-    auto image_size = decoded->get_image_size();
-    shared_ptr<augment::image::params> params_ptr = factory.make_params(image_size.width, image_size.height, config_ptr.width, config_ptr.height);
+    auto                               image_size = decoded->get_image_size();
+    shared_ptr<augment::image::params> params_ptr = factory.make_params(
+        image_size.width, image_size.height, config_ptr.width, config_ptr.height);
 
     image::transformer         trans{config_ptr};
     shared_ptr<image::decoded> transformed = trans.transform(params_ptr, decoded);
@@ -869,13 +863,11 @@ TEST(image, var_resize_fixed_scale)
     vector<unsigned char> img;
     cv::imencode(".png", mat, img);
 
-    nlohmann::json jsConfig = {{"width", 400},
-                               {"height", 400},
-                               {"channels", 3}};
+    nlohmann::json jsConfig = {{"width", 400}, {"height", 400}, {"channels", 3}};
     nlohmann::json aug      = {{"type", "image"},
-                               {"fixed_aspect_ratio", true},
-                               {"crop_enable", false},
-                               {"fixed_scaling_factor", 1.0}};
+                          {"fixed_aspect_ratio", true},
+                          {"crop_enable", false},
+                          {"fixed_scaling_factor", 1.0}};
 
     image::config config_ptr{jsConfig};
 
@@ -889,8 +881,9 @@ TEST(image, var_resize_fixed_scale)
     }
 
     augment::image::param_factory      factory(aug);
-    auto image_size = decoded->get_image_size();
-    shared_ptr<augment::image::params> params_ptr = factory.make_params(image_size.width, image_size.height, config_ptr.width, config_ptr.height);
+    auto                               image_size = decoded->get_image_size();
+    shared_ptr<augment::image::params> params_ptr = factory.make_params(
+        image_size.width, image_size.height, config_ptr.width, config_ptr.height);
 
     image::transformer         trans{config_ptr};
     shared_ptr<image::decoded> transformed = trans.transform(params_ptr, decoded);
@@ -905,24 +898,21 @@ TEST(image, var_transform_flip)
     auto                  indexed = generate_indexed_image();
     vector<unsigned char> img;
     cv::imencode(".png", indexed, img);
-    nlohmann::json jsConfig = {{"width", 256},
-                               {"height", 256},
-                               {"channels", 3}};
-    nlohmann::json aug      = {{"type", "image"},
-                               {"fixed_aspect_ratio", true},
-                               {"crop_enable", false}};
+    nlohmann::json jsConfig = {{"width", 256}, {"height", 256}, {"channels", 3}};
+    nlohmann::json aug = {{"type", "image"}, {"fixed_aspect_ratio", true}, {"crop_enable", false}};
 
     image::config config_ptr{jsConfig};
 
     image::extractor           ext{config_ptr};
     shared_ptr<image::decoded> decoded = ext.extract((char*)&img[0], img.size());
 
-    std::default_random_engine dre;
-    augment::image::param_factory       factory(aug);
+    std::default_random_engine    dre;
+    augment::image::param_factory factory(aug);
 
-    auto image_size = decoded->get_image_size();
-    shared_ptr<augment::image::params> params_ptr = factory.make_params(image_size.width, image_size.height, config_ptr.width, config_ptr.height);
-    params_ptr->flip                     = true;
+    auto                               image_size = decoded->get_image_size();
+    shared_ptr<augment::image::params> params_ptr = factory.make_params(
+        image_size.width, image_size.height, config_ptr.width, config_ptr.height);
+    params_ptr->flip = true;
 
     image::transformer         trans{config_ptr};
     shared_ptr<image::decoded> transformed = trans.transform(params_ptr, decoded);
@@ -971,7 +961,7 @@ bool test_contrast_image(cv::Mat m, float v1, float v2, float v3)
     {
         INFO << m.at<cv::Vec3b>(0, 0);
         INFO << m.at<cv::Vec3b>(128, 0);
-        INFO << m.at<cv::Vec3b>(256, 0);    
+        INFO << m.at<cv::Vec3b>(256, 0);
     }
 
     return rc;
@@ -1128,7 +1118,7 @@ bool test_saturation(cv::Mat m, vector<float> v1, vector<float> v2, vector<float
     {
         INFO << m.at<cv::Vec3b>(0, 0);
         INFO << m.at<cv::Vec3b>(128, 0);
-        INFO << m.at<cv::Vec3b>(256, 0);    
+        INFO << m.at<cv::Vec3b>(256, 0);
     }
 
     return rc;
@@ -1181,7 +1171,7 @@ TEST(DISABLED_photometric, saturation)
         image::photometric::cbsjitter(mat, 1.0, 1.0, 1.0);
         cv::imwrite("saturation_1_0.png", mat);
         EXPECT_TRUE(test_saturation(mat, {128, 0, 0}, {0, 128, 0}, {0, 0, 128}));
-    } 
+    }
 
     {
         cv::Mat mat = source.clone();
@@ -1273,7 +1263,7 @@ TEST(DISABLED_photometric, hue)
     }
 
     {
-        for (int i = 0; i <= 180; i += 45/2)
+        for (int i = 0; i <= 180; i += 45 / 2)
         {
             cv::Mat mat = source.clone();
             image::photometric::cbsjitter(mat, 1.0, 1.0, 1.0, i);

--- a/test/test_label_map.cpp
+++ b/test/test_label_map.cpp
@@ -96,14 +96,14 @@ TEST(label_map, test)
             loader.load({buffer.data()}, decoded);
 
             char* data_p = buffer.data();
-            int  i      = 0;
+            int   i      = 0;
             for (; i < expected.size(); i++)
             {
-                EXPECT_EQ(expected[i], unpack<int32_t>(&data_p[i*sizeof(int32_t)]));
+                EXPECT_EQ(expected[i], unpack<int32_t>(&data_p[i * sizeof(int32_t)]));
             }
             for (; i < cfg.max_label_count(); i++)
             {
-                EXPECT_EQ(0, unpack<int32_t>(&data_p[i*sizeof(int32_t)]));
+                EXPECT_EQ(0, unpack<int32_t>(&data_p[i * sizeof(int32_t)]));
             }
             // check for overrun
             for (i *= 4; i < buffer_size; i++)

--- a/test/test_loader.cpp
+++ b/test/test_loader.cpp
@@ -51,54 +51,43 @@ TEST(loader, syntax)
     string manifest      = manifest_root + "/manifest.csv";
 
     nlohmann::json image = {{"type", "image"},
-                           {"name", "image1"},
-                           {"height", height},
-                           {"width", width},
-                           {"channel_major", false}};
-    nlohmann::json label = {{"type", "label"},
-                           {"name", "label1"},
-                           {"binary", false}};
-    nlohmann::json augmentation = {{"type", "image"},
+                            {"name", "image1"},
                             {"height", height},
                             {"width", width},
-                            {"flip_enable", true}};
-    nlohmann::json js = {
-                         {"manifest_root", manifest_root},
+                            {"channel_major", false}};
+    nlohmann::json label        = {{"type", "label"}, {"name", "label1"}, {"binary", false}};
+    nlohmann::json augmentation = {
+        {"type", "image"}, {"height", height}, {"width", width}, {"flip_enable", true}};
+    nlohmann::json js = {{"manifest_root", manifest_root},
                          {"manifest_filename", manifest},
                          {"batch_size", batch_size},
                          {"iteration_mode", "INFINITE"},
                          {"etl", {image, label}},
-                         {"augmentation", {augmentation}}
-                         };
+                         {"augmentation", {augmentation}}};
 
     auto train_set = loader{js};
 }
 
 TEST(loader, iterator)
 {
-    int            height            = 32;
-    int            width             = 32;
-    size_t         batch_size        = 1;
-    size_t         record_count      = 10;
-    string         manifest_filename = create_manifest_file(record_count, width, height);
+    int    height            = 32;
+    int    width             = 32;
+    size_t batch_size        = 1;
+    size_t record_count      = 10;
+    string manifest_filename = create_manifest_file(record_count, width, height);
 
     nlohmann::json image = {{"type", "image"},
-                           {"name", "image1"},
-                           {"height", height},
-                           {"width", width},
-                           {"channel_major", false}};
-    nlohmann::json label = {{"type", "label"},
-                           {"name", "label1"},
-                           {"binary", false}};
-    nlohmann::json augmentation = {{"type", "image"},
-                            {"flip_enable", true}};
-    nlohmann::json js = {
-                         {"manifest_filename", manifest_filename},
+                            {"name", "image1"},
+                            {"height", height},
+                            {"width", width},
+                            {"channel_major", false}};
+    nlohmann::json label        = {{"type", "label"}, {"name", "label1"}, {"binary", false}};
+    nlohmann::json augmentation = {{"type", "image"}, {"flip_enable", true}};
+    nlohmann::json js           = {{"manifest_filename", manifest_filename},
                          {"batch_size", batch_size},
                          {"iteration_mode", "ONCE"},
                          {"etl", {image, label}},
-                         {"augmentation", {augmentation}}
-                         };
+                         {"augmentation", {augmentation}}};
 
     loader train_set{js};
 
@@ -124,29 +113,24 @@ TEST(loader, iterator)
 
 TEST(loader, once)
 {
-    int            height            = 32;
-    int            width             = 32;
-    size_t         batch_size        = 2;
-    size_t         record_count      = 10;
-    string         manifest_filename = create_manifest_file(record_count, width, height);
+    int    height            = 32;
+    int    width             = 32;
+    size_t batch_size        = 2;
+    size_t record_count      = 10;
+    string manifest_filename = create_manifest_file(record_count, width, height);
 
     nlohmann::json image = {{"type", "image"},
-                           {"name", "image1"},
-                           {"height", height},
-                           {"width", width},
-                           {"channel_major", false}};
-    nlohmann::json label = {{"type", "label"},
-                           {"name", "label1"},
-                           {"binary", false}};
-    nlohmann::json augmentation = {{"type", "image"},
-                            {"flip_enable", true}};
-    nlohmann::json js = {
-                         {"manifest_filename", manifest_filename},
+                            {"name", "image1"},
+                            {"height", height},
+                            {"width", width},
+                            {"channel_major", false}};
+    nlohmann::json label        = {{"type", "label"}, {"name", "label1"}, {"binary", false}};
+    nlohmann::json augmentation = {{"type", "image"}, {"flip_enable", true}};
+    nlohmann::json js           = {{"manifest_filename", manifest_filename},
                          {"batch_size", batch_size},
                          {"iteration_mode", "ONCE"},
                          {"etl", {image, label}},
-                         {"augmentation", {augmentation}}
-                         };
+                         {"augmentation", {augmentation}}};
 
     loader train_set{js};
 
@@ -157,35 +141,30 @@ TEST(loader, once)
         ASSERT_NE(count, record_count);
         count++;
     }
-    ASSERT_EQ(record_count/2, count);
+    ASSERT_EQ(record_count / 2, count);
 }
 
 TEST(loader, count)
 {
-    int            height            = 32;
-    int            width             = 32;
-    size_t         batch_size        = 1;
-    size_t         record_count      = 10;
-    string         manifest_filename = create_manifest_file(record_count, width, height);
+    int    height            = 32;
+    int    width             = 32;
+    size_t batch_size        = 1;
+    size_t record_count      = 10;
+    string manifest_filename = create_manifest_file(record_count, width, height);
 
     nlohmann::json image = {{"type", "image"},
-                           {"name", "image1"},
-                           {"height", height},
-                           {"width", width},
-                           {"channel_major", false}};
-    nlohmann::json label = {{"type", "label"},
-                           {"name", "label1"},
-                           {"binary", false}};
-    nlohmann::json augmentation = {{"type", "image"},
-                            {"flip_enable", true}};
-    nlohmann::json js = {
-                         {"manifest_filename", manifest_filename},
+                            {"name", "image1"},
+                            {"height", height},
+                            {"width", width},
+                            {"channel_major", false}};
+    nlohmann::json label        = {{"type", "label"}, {"name", "label1"}, {"binary", false}};
+    nlohmann::json augmentation = {{"type", "image"}, {"flip_enable", true}};
+    nlohmann::json js           = {{"manifest_filename", manifest_filename},
                          {"batch_size", batch_size},
                          {"iteration_mode", "COUNT"},
                          {"iteration_mode_count", 4},
                          {"etl", {image, label}},
-                         {"augmentation", {augmentation}}
-                         };
+                         {"augmentation", {augmentation}}};
 
     int expected_iterations = 4;
 
@@ -204,29 +183,24 @@ TEST(loader, count)
 
 TEST(loader, infinite)
 {
-    int            height            = 32;
-    int            width             = 32;
-    size_t         batch_size        = 1;
-    size_t         record_count      = 10;
-    string         manifest_filename = create_manifest_file(record_count, width, height);
+    int    height            = 32;
+    int    width             = 32;
+    size_t batch_size        = 1;
+    size_t record_count      = 10;
+    string manifest_filename = create_manifest_file(record_count, width, height);
 
     nlohmann::json image = {{"type", "image"},
-                           {"name", "image1"},
-                           {"height", height},
-                           {"width", width},
-                           {"channel_major", false}};
-    nlohmann::json label = {{"type", "label"},
-                           {"name", "label1"},
-                           {"binary", false}};
-    nlohmann::json augmentation = {{"type", "image"},
-                            {"flip_enable", true}};
-    nlohmann::json js = {
-                         {"manifest_filename", manifest_filename},
+                            {"name", "image1"},
+                            {"height", height},
+                            {"width", width},
+                            {"channel_major", false}};
+    nlohmann::json label        = {{"type", "label"}, {"name", "label1"}, {"binary", false}};
+    nlohmann::json augmentation = {{"type", "image"}, {"flip_enable", true}};
+    nlohmann::json js           = {{"manifest_filename", manifest_filename},
                          {"batch_size", batch_size},
                          {"iteration_mode", "INFINITE"},
                          {"etl", {image, label}},
-                         {"augmentation", {augmentation}}
-                         };
+                         {"augmentation", {augmentation}}};
 
     loader train_set{js};
 
@@ -246,33 +220,28 @@ TEST(loader, infinite)
 
 TEST(loader, cache)
 {
-    int            height            = 16;
-    int            width             = 16;
-    size_t         batch_size        = 32;
-    size_t         record_count      = 1002;
-    size_t         block_size        = 300;
-    string         cache_root        = file_util::get_temp_directory();
-    string         manifest_filename = create_manifest_file(record_count, width, height);
+    int    height            = 16;
+    int    width             = 16;
+    size_t batch_size        = 32;
+    size_t record_count      = 1002;
+    size_t block_size        = 300;
+    string cache_root        = file_util::get_temp_directory();
+    string manifest_filename = create_manifest_file(record_count, width, height);
 
     nlohmann::json image = {{"type", "image"},
-                           {"name", "image1"},
-                           {"height", height},
-                           {"width", width},
-                           {"channel_major", false}};
-    nlohmann::json label = {{"type", "label"},
-                           {"name", "label1"},
-                           {"binary", false}};
-    nlohmann::json augmentation = {{"type", "image"},
-                            {"flip_enable", true}};
-    nlohmann::json js = {
-                         {"manifest_filename", manifest_filename},
+                            {"name", "image1"},
+                            {"height", height},
+                            {"width", width},
+                            {"channel_major", false}};
+    nlohmann::json label        = {{"type", "label"}, {"name", "label1"}, {"binary", false}};
+    nlohmann::json augmentation = {{"type", "image"}, {"flip_enable", true}};
+    nlohmann::json js           = {{"manifest_filename", manifest_filename},
                          {"batch_size", batch_size},
                          {"block_size", block_size},
                          {"cache_directory", cache_root},
                          {"iteration_mode", "INFINITE"},
                          {"etl", {image, label}},
-                         {"augmentation", {augmentation}}
-                         };
+                         {"augmentation", {augmentation}}};
 
     loader train_set{js};
 
@@ -292,28 +261,22 @@ TEST(loader, cache)
 
 TEST(loader, test)
 {
-    int            height            = 16;
-    int            width             = 16;
-    size_t         batch_size        = 32;
-    size_t         record_count      = 1003;
-    size_t         block_size        = 300;
-    string         manifest_filename = create_manifest_file(record_count, width, height);
+    int    height            = 16;
+    int    width             = 16;
+    size_t batch_size        = 32;
+    size_t record_count      = 1003;
+    size_t block_size        = 300;
+    string manifest_filename = create_manifest_file(record_count, width, height);
 
-    nlohmann::json js_image = {{"type", "image"},
-                           {"height", height},
-                           {"width", width},
-                           {"channel_major", false}};
-    nlohmann::json label = {{"type", "label"},
-                           {"binary", false}};
-    nlohmann::json augmentation = {{"type", "image"},
-                            {"flip_enable", true}};
-    nlohmann::json js = {
-                         {"manifest_filename", manifest_filename},
+    nlohmann::json js_image = {
+        {"type", "image"}, {"height", height}, {"width", width}, {"channel_major", false}};
+    nlohmann::json label        = {{"type", "label"}, {"binary", false}};
+    nlohmann::json augmentation = {{"type", "image"}, {"flip_enable", true}};
+    nlohmann::json js           = {{"manifest_filename", manifest_filename},
                          {"batch_size", batch_size},
                          {"block_size", block_size},
                          {"etl", {js_image, label}},
-                         {"augmentation", {augmentation}}
-                         };
+                         {"augmentation", {augmentation}}};
 
     loader train_set{js};
 
@@ -360,24 +323,18 @@ TEST(loader, test)
 
 TEST(loader, custom_provider)
 {
-    int            height            = 16;
-    int            width             = 16;
-    size_t         batch_size        = 32;
-    size_t         record_count      = 1003;
-    string         manifest = create_manifest_file(record_count, width, height);
+    int    height       = 16;
+    int    width        = 16;
+    size_t batch_size   = 32;
+    size_t record_count = 1003;
+    string manifest     = create_manifest_file(record_count, width, height);
 
-    nlohmann::json image_config = {{"type", "image"},
-                           {"height", height},
-                           {"width", width},
-                           {"channel_major", false}};
-    nlohmann::json label_config = {{"type", "label"},
-                            {"binary", false}};
-    nlohmann::json augmentation = {{"height", height},
-                            {"width", width},
-                            {"type", "image"},
-                            {"flip_enable", true}};
-    nlohmann::json js = {
-                         {"single_thread", true},
+    nlohmann::json image_config = {
+        {"type", "image"}, {"height", height}, {"width", width}, {"channel_major", false}};
+    nlohmann::json label_config = {{"type", "label"}, {"binary", false}};
+    nlohmann::json augmentation = {
+        {"height", height}, {"width", width}, {"type", "image"}, {"flip_enable", true}};
+    nlohmann::json js = {{"single_thread", true},
                          {"manifest_filename", manifest},
                          {"batch_size", batch_size},
                          {"iteration_mode", "INFINITE"},
@@ -438,33 +395,32 @@ TEST(benchmark, imagenet)
     }
     else
     {
-        int    height        = 224;
-        int    width         = 224;
-        size_t batch_size    = 128;
-        string manifest      = file_util::path_join(manifest_root, "train-index.tsv");
+        int    height     = 224;
+        int    width      = 224;
+        size_t batch_size = 128;
+        string manifest   = file_util::path_join(manifest_root, "train-index.tsv");
 
         nlohmann::json js = {{"type", "image,label"},
-                                {"manifest_root", manifest_root},
-                                {"manifest_filename", manifest},
-                                {"batch_size", batch_size},
-                                {"iteration_mode", "INFINITE"},
-                                {"cache_directory", cache_root},
-                                {"single_thread", false},
-                                {"image",
-                                    {{"height", height},
-                                    {"width", width},
-                                    {"channel_major", false},
-                                    // {"angle", {-90, 90}},
-                                    {"scale", {0.5, 1.0}},
-                                    // {"hue", {-360, 360}},
-                                    {"saturation", {0.5, 2.0}},
-                                    {"contrast", {0.5, 1.0}},
-                                    {"brightness", {0.5, 1.0}},
-                                    {"flip_enable", true}}
-                                },
-                                {"label", {{"binary", false}}}};
+                             {"manifest_root", manifest_root},
+                             {"manifest_filename", manifest},
+                             {"batch_size", batch_size},
+                             {"iteration_mode", "INFINITE"},
+                             {"cache_directory", cache_root},
+                             {"single_thread", false},
+                             {"image",
+                              {{"height", height},
+                               {"width", width},
+                               {"channel_major", false},
+                               // {"angle", {-90, 90}},
+                               {"scale", {0.5, 1.0}},
+                               // {"hue", {-360, 360}},
+                               {"saturation", {0.5, 2.0}},
+                               {"contrast", {0.5, 1.0}},
+                               {"brightness", {0.5, 1.0}},
+                               {"flip_enable", true}}},
+                             {"label", {{"binary", false}}}};
 
-        chrono::high_resolution_clock timer;
+        chrono::high_resolution_clock                     timer;
         chrono::time_point<chrono::high_resolution_clock> start_time;
         chrono::time_point<chrono::high_resolution_clock> zero_time;
         chrono::time_point<chrono::high_resolution_clock> total_time;
@@ -472,29 +428,29 @@ TEST(benchmark, imagenet)
         {
             auto train_set = nervana::loader{js};
 
-            size_t total_batch = ceil((float)train_set.record_count() / (float)batch_size);
-            size_t current_batch = 0;
+            size_t       total_batch   = ceil((float)train_set.record_count() / (float)batch_size);
+            size_t       current_batch = 0;
             const size_t batches_per_output = 10;
-            total_time = timer.now();
+            total_time                      = timer.now();
             for (const nervana::fixed_buffer_map& x : train_set)
             {
                 (void)x;
                 if (++current_batch % batches_per_output == 0)
                 {
                     auto last_time = start_time;
-                    start_time = timer.now();
+                    start_time     = timer.now();
                     float ms_time =
-                        chrono::duration_cast<chrono::milliseconds>(start_time - last_time)
-                            .count();
+                        chrono::duration_cast<chrono::milliseconds>(start_time - last_time).count();
                     float sec_time = ms_time / 1000.;
                     cout << "batch " << current_batch << " of " << total_batch;
                     if (last_time != zero_time)
                     {
                         cout << " time " << ms_time;
                         cout << " " << (float)batches_per_output / sec_time << " batches/s";
-                    float t_time =
-                        chrono::duration_cast<chrono::milliseconds>(start_time - total_time)
-                            .count() / 1000.;
+                        float t_time =
+                            chrono::duration_cast<chrono::milliseconds>(start_time - total_time)
+                                .count() /
+                            1000.;
                         cout << "\t\taverage " << (float)current_batch / t_time << " batches/s";
                     }
                     cout << endl;
@@ -503,7 +459,7 @@ TEST(benchmark, imagenet)
                 // if (current_batch == 30) break;
             }
         }
-        catch(exception& err)
+        catch (exception& err)
         {
             cout << "error processing dataset" << endl;
             cout << err.what() << endl;
@@ -514,37 +470,37 @@ TEST(benchmark, imagenet)
 TEST(benchmark, decode_jpeg)
 {
     stopwatch timer;
-    size_t manifest_size = 10000;
-    string image_path = file_util::path_join(CURDIR, "test_data/img_2112_70.jpg");
+    size_t    manifest_size = 10000;
+    string    image_path    = file_util::path_join(CURDIR, "test_data/img_2112_70.jpg");
 
     vector<char> image_data = file_util::read_file_contents(image_path);
     timer.start();
-    for (size_t i=0; i<manifest_size; i++)
+    for (size_t i = 0; i < manifest_size; i++)
     {
         cv::Mat output_img;
         cv::Mat input_img(1, image_data.size(), CV_8UC3, image_data.data());
         cv::imdecode(input_img, CV_8UC3, &output_img);
     }
     auto time = (float)timer.get_milliseconds() / 1000.;
-    cout << ((float)manifest_size/time) << " images/second " << endl;
+    cout << ((float)manifest_size / time) << " images/second " << endl;
 }
 
 TEST(benchmark, read_jpeg)
 {
     stopwatch timer;
 
-    size_t manifest_size = 10000;
-    string image_path = file_util::path_join(CURDIR, "test_data/img_2112_70.jpg");
+    size_t       manifest_size = 10000;
+    string       image_path    = file_util::path_join(CURDIR, "test_data/img_2112_70.jpg");
     stringstream manifest_stream;
-    for (size_t i=0; i<manifest_size; i++)
+    for (size_t i = 0; i < manifest_size; i++)
     {
         manifest_stream << image_path << "\n";
     }
     manifest_file manifest{manifest_stream, false};
 
     vector<vector<string>>* block = nullptr;
-    size_t count = 0;
-    size_t mod = 10000;
+    size_t                  count = 0;
+    size_t                  mod   = 10000;
     timer.start();
     for (block = manifest.next(); block != nullptr; block = manifest.next())
     {
@@ -552,13 +508,13 @@ TEST(benchmark, read_jpeg)
         {
             count++;
             vector<char> image_data = file_util::read_file_contents(record[0]);
-            cv::Mat output_img;
-            cv::Mat input_img(1, image_data.size(), CV_8UC3, image_data.data());
+            cv::Mat      output_img;
+            cv::Mat      input_img(1, image_data.size(), CV_8UC3, image_data.data());
             cv::imdecode(input_img, CV_8UC3, &output_img);
             if (count % mod == 0)
             {
                 auto time = (float)timer.get_milliseconds() / 1000.;
-                cout << ((float)count/time) << " images/second " << endl;
+                cout << ((float)count / time) << " images/second " << endl;
             }
         }
     }
@@ -569,25 +525,25 @@ TEST(benchmark, load_jpeg)
     stopwatch timer;
 
     size_t manifest_size = 10000;
-    string image_path = file_util::path_join(CURDIR, "test_data/img_2112_70.jpg");
+    string image_path    = file_util::path_join(CURDIR, "test_data/img_2112_70.jpg");
 
     timer.start();
-    for (size_t i=0; i<manifest_size; i++)
+    for (size_t i = 0; i < manifest_size; i++)
     {
         auto data = file_util::read_file_contents(image_path);
     }
     auto time = (float)timer.get_milliseconds() / 1000.;
-    cout << "images/second " << ((float)manifest_size/time) << endl;
+    cout << "images/second " << ((float)manifest_size / time) << endl;
 }
 
 TEST(benchmark, load_jpeg_manifest)
 {
     stopwatch timer;
 
-    size_t manifest_size = 10000;
-    string image_path = file_util::path_join(CURDIR, "test_data/img_2112_70.jpg");
+    size_t       manifest_size = 10000;
+    string       image_path    = file_util::path_join(CURDIR, "test_data/img_2112_70.jpg");
     stringstream manifest_stream;
-    for (size_t i=0; i<manifest_size; i++)
+    for (size_t i = 0; i < manifest_size; i++)
     {
         manifest_stream << image_path << "\n";
     }
@@ -603,20 +559,20 @@ TEST(benchmark, load_jpeg_manifest)
         }
     }
     auto time = (float)timer.get_milliseconds() / 1000.;
-    cout << "images/second " << ((float)manifest_size/time) << endl;
+    cout << "images/second " << ((float)manifest_size / time) << endl;
 }
 
 TEST(benchmark, load_block_manager)
 {
     stopwatch timer;
-    string cache_directory = "/scratch/bob/aeon_cache";
-    bool shuffle = false;
-    size_t block_size = 5000;
+    string    cache_directory = "/scratch/bob/aeon_cache";
+    bool      shuffle         = false;
+    size_t    block_size      = 5000;
 
-    size_t manifest_size = 30000;
-    string image_path = file_util::path_join(CURDIR, "test_data/img_2112_70.jpg");
+    size_t       manifest_size = 30000;
+    string       image_path    = file_util::path_join(CURDIR, "test_data/img_2112_70.jpg");
     stringstream manifest_stream;
-    for (size_t i=0; i<manifest_size; i++)
+    for (size_t i = 0; i < manifest_size; i++)
     {
         manifest_stream << image_path << "\n";
     }
@@ -628,14 +584,14 @@ TEST(benchmark, load_block_manager)
 
     encoded_record_list* records;
     timer.start();
-    float count = 0;
+    float  count      = 0;
     size_t iterations = (manifest_size / block_size) * 3;
-    for (size_t i=0; i<iterations; i++)
+    for (size_t i = 0; i < iterations; i++)
     {
         records = manager.next();
         timer.stop();
-        count = records->size();
-        float time = timer.get_microseconds()/1000000.;
+        count      = records->size();
+        float time = timer.get_microseconds() / 1000000.;
         cout << "count=" << count << ", time=" << time << " images/second " << count / time << endl;
         timer.start();
     }

--- a/test/test_localization.cpp
+++ b/test/test_localization.cpp
@@ -72,22 +72,20 @@ vector<uint8_t> make_image_from_metadata(const std::string& metadata)
 
 TEST(DISABLED_localization, example)
 {
-    int height = 1000;
-    int width = 1000;
-    int batch_size = 1;
-    float fixed_scaling_factor = 1.6;
-    std::string manifest_root = "/test_data";
-    std::string manifest      = "localization_manifest.tsv";
-    std::vector<std::string> class_names = {"bicycle", "person"};
+    int                      height               = 1000;
+    int                      width                = 1000;
+    int                      batch_size           = 1;
+    float                    fixed_scaling_factor = 1.6;
+    std::string              manifest_root        = "/test_data";
+    std::string              manifest             = "localization_manifest.tsv";
+    std::vector<std::string> class_names          = {"bicycle", "person"};
 
-    nlohmann::json js_image = {{"type", "image"},
-                               {"height", height},
-                               {"width", width},
-                               {"channel_major", false}};
+    nlohmann::json js_image = {
+        {"type", "image"}, {"height", height}, {"width", width}, {"channel_major", false}};
     nlohmann::json js_local = {{"type", "localization"},
                                {"height", height},
-                               {"width", width}, 
-                               {"max_gt_boxes", 64}, 
+                               {"width", width},
+                               {"max_gt_boxes", 64},
                                {"class_names", class_names}};
     nlohmann::json js_aug = {{"type", "image"},
                              {"fixed_aspect_ratio", true},
@@ -136,20 +134,16 @@ TEST(localization, generate_anchors)
     // subtract 1 from the expected vector as it was generated with 1's based matlab
     //    expected -= 1;
 
-    int height = 1000;
-    int width = 1000;
-    nlohmann::json js_image = {{"width", width},
-                               {"height", height}, 
-                               {"channels", 3}};
-    nlohmann::json js_aug = {{"type", "image"},
+    int            height   = 1000;
+    int            width    = 1000;
+    nlohmann::json js_image = {{"width", width}, {"height", height}, {"channels", 3}};
+    nlohmann::json js_aug   = {{"type", "image"},
                              {"flip_enable", false},
                              {"crop_enable", false},
                              {"fixed_aspect_ratio", true},
                              {"fixed_scaling_factor", 1.6}};
-    nlohmann::json js_loc = {{"width", width},
-                             {"height", height},
-                             {"class_names", label_list},
-                             {"max_gt_boxes", 64}};
+    nlohmann::json js_loc = {
+        {"width", width}, {"height", height}, {"class_names", label_list}, {"max_gt_boxes", 64}};
 
     localization::config cfg{js_loc};
 
@@ -205,16 +199,14 @@ void plot(const vector<box>& list, const string& prefix)
 
 void plot(const string& path)
 {
-    string                    prefix = path.substr(path.size() - 11, 6) + "-";
-    string                    data   = read_file(path);
-    int width = 1000;
-    int height = 1000;
-    nlohmann::json js_loc = {{"width", width},
-                            {"height", height},
-                            {"class_names", label_list},
-                            {"max_gt_boxes", 64}};
+    string         prefix = path.substr(path.size() - 11, 6) + "-";
+    string         data   = read_file(path);
+    int            width  = 1000;
+    int            height = 1000;
+    nlohmann::json js_loc = {
+        {"width", width}, {"height", height}, {"class_names", label_list}, {"max_gt_boxes", 64}};
 
-    localization::config cfg{js_loc};
+    localization::config      cfg{js_loc};
     localization::extractor   extractor{cfg};
     localization::transformer transformer{cfg, -1};
     auto                      extracted_metadata = extractor.extract(&data[0], data.size());
@@ -309,7 +301,8 @@ void plot(const string& path)
 
 TEST(localization, config)
 {
-    nlohmann::json js  = {{"height", 300}, {"width", 400}, {"class_names", label_list}, {"max_gt_boxes", 100}};
+    nlohmann::json js = {
+        {"height", 300}, {"width", 400}, {"class_names", label_list}, {"max_gt_boxes", 100}};
 
     EXPECT_NO_THROW(localization::config cfg(js));
 }
@@ -317,39 +310,39 @@ TEST(localization, config)
 // not sure how we want to handle this error with new augmentation system
 TEST(DISABLED_localization, config_rotate)
 {
-    nlohmann::json js = {{"height", 300}, {"width", 400}, {"class_names", label_list}, {"max_gt_boxes", 100}};
+    nlohmann::json js = {
+        {"height", 300}, {"width", 400}, {"class_names", label_list}, {"max_gt_boxes", 100}};
 
     EXPECT_THROW(localization::config cfg(js), std::invalid_argument);
 }
 
 TEST(localization, sample_anchors)
 {
-    string                    data         = read_file(CURDIR "/test_data/006637.json");
-    int height = 1000;
-    int width = 1000;
+    string         data     = read_file(CURDIR "/test_data/006637.json");
+    int            height   = 1000;
+    int            width    = 1000;
     nlohmann::json js_image = {{"width", width}, {"height", height}, {"channels", 3}};
-    nlohmann::json js_loc = {{"width", width},
-                            {"height", height},
-                            {"class_names", label_list},
-                            {"max_gt_boxes", 64}};
+    nlohmann::json js_loc   = {
+        {"width", width}, {"height", height}, {"class_names", label_list}, {"max_gt_boxes", 64}};
     nlohmann::json js_aug = {{"type", "image"},
-                               {"flip_enable", false},
-                               {"crop_enable", false},
-                               {"fixed_aspect_ratio", true},
-                               {"fixed_scaling_factor", 1.6}};
-    image::config image_config{js_image};
-    localization::config cfg{js_loc};
+                             {"flip_enable", false},
+                             {"crop_enable", false},
+                             {"fixed_aspect_ratio", true},
+                             {"fixed_scaling_factor", 1.6}};
+    image::config                 image_config{js_image};
+    localization::config          cfg{js_loc};
     augment::image::param_factory factory(js_aug);
-    localization::extractor   extractor{cfg};
-    localization::transformer transformer{cfg, factory.fixed_scaling_factor};
-    auto                      extracted_metadata = extractor.extract(&data[0], data.size());
+    localization::extractor       extractor{cfg};
+    localization::transformer     transformer{cfg, factory.fixed_scaling_factor};
+    auto                          extracted_metadata = extractor.extract(&data[0], data.size());
     ASSERT_NE(nullptr, extracted_metadata);
 
-    vector<unsigned char>      img = make_image_from_metadata(data);
-    image::extractor           ext{image_config};
-    shared_ptr<image::decoded> decoded = ext.extract((char*)&img[0], img.size());
-    auto image_size = decoded->get_image_size();
-    shared_ptr<augment::image::params>  params = factory.make_params(image_size.width, image_size.height, cfg.width, cfg.height);
+    vector<unsigned char>              img = make_image_from_metadata(data);
+    image::extractor                   ext{image_config};
+    shared_ptr<image::decoded>         decoded    = ext.extract((char*)&img[0], img.size());
+    auto                               image_size = decoded->get_image_size();
+    shared_ptr<augment::image::params> params =
+        factory.make_params(image_size.width, image_size.height, cfg.width, cfg.height);
 
     auto transformed_metadata = transformer.transform(params, extracted_metadata);
     ASSERT_NE(nullptr, transformed_metadata);
@@ -383,28 +376,27 @@ TEST(localization, transform_scale)
 {
     string          metadata   = read_file(CURDIR "/test_data/006637.json");
     vector<uint8_t> image_data = make_image_from_metadata(metadata);
-    int width = 600;
-    int height = 600;
-    nlohmann::json js_image = {{"width", width}, {"height", height}, {"channels", 3}};
-    nlohmann::json js_loc = {{"width", width},
-                            {"height", height},
-                            {"class_names", label_list},
-                            {"max_gt_boxes", 64}};
+    int             width      = 600;
+    int             height     = 600;
+    nlohmann::json  js_image   = {{"width", width}, {"height", height}, {"channels", 3}};
+    nlohmann::json  js_loc     = {
+        {"width", width}, {"height", height}, {"class_names", label_list}, {"max_gt_boxes", 64}};
     nlohmann::json js_aug = {{"type", "image"},
-                               {"flip_enable", false},
-                               {"crop_enable", false},
-                               {"fixed_aspect_ratio", true},
-                               {"fixed_scaling_factor", 1.6}};
+                             {"flip_enable", false},
+                             {"crop_enable", false},
+                             {"fixed_aspect_ratio", true},
+                             {"fixed_scaling_factor", 1.6}};
 
-    image::config image_config{js_image};
-    localization::config cfg{js_loc};
+    image::config                 image_config{js_image};
+    localization::config          cfg{js_loc};
     augment::image::param_factory factory{js_aug};
-    image::extractor           image_extractor{image_config};
-    shared_ptr<image::decoded> image_decoded =
+    image::extractor              image_extractor{image_config};
+    shared_ptr<image::decoded>    image_decoded =
         image_extractor.extract((const char*)image_data.data(), image_data.size());
-    auto image_size = image_decoded->get_image_size();
-    shared_ptr<augment::image::params> params = factory.make_params(image_size.width, image_size.height, cfg.width, cfg.height);
-    params->debug_deterministic      = true;
+    auto                               image_size = image_decoded->get_image_size();
+    shared_ptr<augment::image::params> params =
+        factory.make_params(image_size.width, image_size.height, cfg.width, cfg.height);
+    params->debug_deterministic = true;
 
     localization::extractor   extractor{cfg};
     localization::transformer transformer{cfg, factory.fixed_scaling_factor};
@@ -433,30 +425,29 @@ TEST(localization, transform_flip)
 {
     string          metadata   = read_file(CURDIR "/test_data/006637.json");
     vector<uint8_t> image_data = make_image_from_metadata(metadata);
-    int width = 1000;
-    int height = 1000;
-    nlohmann::json js_image = {{"width", width}, {"height", height}, {"channels", 3}};
-    nlohmann::json js_loc = {{"width", width},
-                             {"height", height},
-                             {"class_names", label_list},
-                             {"max_gt_boxes", 64}};
+    int             width      = 1000;
+    int             height     = 1000;
+    nlohmann::json  js_image   = {{"width", width}, {"height", height}, {"channels", 3}};
+    nlohmann::json  js_loc     = {
+        {"width", width}, {"height", height}, {"class_names", label_list}, {"max_gt_boxes", 64}};
     nlohmann::json js_aug = {{"type", "image"},
                              {"flip_enable", false},
                              {"crop_enable", false},
                              {"fixed_aspect_ratio", true},
                              {"fixed_scaling_factor", 1.6}};
 
-    image::config image_config{js_image};
-    localization::config cfg{js_loc};
+    image::config                 image_config{js_image};
+    localization::config          cfg{js_loc};
     augment::image::param_factory factory{js_aug};
-    image::extractor image_extractor{image_config};
+    image::extractor              image_extractor{image_config};
 
     shared_ptr<image::decoded> image_decoded =
         image_extractor.extract((const char*)image_data.data(), image_data.size());
-    auto image_size = image_decoded->get_image_size();
-    shared_ptr<augment::image::params> params = factory.make_params(image_size.width, image_size.height, cfg.width, cfg.height);
-    params->debug_deterministic      = true;
-    params->flip                     = 1;
+    auto                               image_size = image_decoded->get_image_size();
+    shared_ptr<augment::image::params> params =
+        factory.make_params(image_size.width, image_size.height, cfg.width, cfg.height);
+    params->debug_deterministic = true;
+    params->flip                = 1;
 
     localization::extractor   extractor{cfg};
     localization::transformer transformer{cfg, factory.fixed_scaling_factor};
@@ -526,27 +517,26 @@ TEST(localization, transform_crop)
     {
         string          data            = read_file(CURDIR "/test_data/006637.json");
         vector<uint8_t> test_image_data = make_image_from_metadata(data);
-        int width = 600;
-        int height = 600;
+        int             width           = 600;
+        int             height          = 600;
 
         nlohmann::json js_image = {{"width", width}, {"height", height}, {"channels", 3}};
-        nlohmann::json js_loc = {{"width", width},
-                                {"height", height},
-                                {"class_names", label_list},
-                                {"max_gt_boxes", 64}};
-        nlohmann::json js_aug = {{"type", "image"},
-                                {"flip_enable", false},
-                                {"scale", {0.8, 0.8}}};
+        nlohmann::json js_loc   = {{"width", width},
+                                 {"height", height},
+                                 {"class_names", label_list},
+                                 {"max_gt_boxes", 64}};
+        nlohmann::json js_aug = {{"type", "image"}, {"flip_enable", false}, {"scale", {0.8, 0.8}}};
 
-        image::config image_config{js_image};
-        localization::config cfg{js_loc};
+        image::config                 image_config{js_image};
+        localization::config          cfg{js_loc};
         augment::image::param_factory factory{js_aug};
-        image::extractor image_extractor{image_config};
+        image::extractor              image_extractor{image_config};
 
         shared_ptr<image::decoded> image_decoded =
             image_extractor.extract((const char*)test_image_data.data(), test_image_data.size());
-        auto image_size = image_decoded->get_image_size();
-        shared_ptr<augment::image::params> params = factory.make_params(image_size.width, image_size.height, cfg.width, cfg.height);
+        auto                               image_size = image_decoded->get_image_size();
+        shared_ptr<augment::image::params> params =
+            factory.make_params(image_size.width, image_size.height, cfg.width, cfg.height);
 
         localization::extractor   extractor{cfg};
         localization::transformer transformer{cfg, factory.fixed_scaling_factor};
@@ -568,27 +558,26 @@ TEST(localization, transform_crop)
     {
         string          data            = read_file(CURDIR "/test_data/006637.json");
         vector<uint8_t> test_image_data = make_image_from_metadata(data);
-        int width = 600;
-        int height = 600;
+        int             width           = 600;
+        int             height          = 600;
 
         nlohmann::json js_image = {{"width", width}, {"height", height}, {"channels", 3}};
-        nlohmann::json js_loc = {{"width", width},
-                                {"height", height},
-                                {"class_names", label_list},
-                                {"max_gt_boxes", 64}};
-        nlohmann::json js_aug = {{"type", "image"},
-                                {"flip_enable", false},
-                                {"scale", {0.2, 0.2}}};
+        nlohmann::json js_loc   = {{"width", width},
+                                 {"height", height},
+                                 {"class_names", label_list},
+                                 {"max_gt_boxes", 64}};
+        nlohmann::json js_aug = {{"type", "image"}, {"flip_enable", false}, {"scale", {0.2, 0.2}}};
 
-        image::config image_config{js_image};
-        localization::config cfg{js_loc};
+        image::config                 image_config{js_image};
+        localization::config          cfg{js_loc};
         augment::image::param_factory factory{js_aug};
-        image::extractor image_extractor{image_config};
+        image::extractor              image_extractor{image_config};
 
         shared_ptr<image::decoded> image_decoded =
             image_extractor.extract((const char*)test_image_data.data(), test_image_data.size());
-        auto image_size = image_decoded->get_image_size();
-        shared_ptr<augment::image::params> params = factory.make_params(image_size.width, image_size.height, cfg.width, cfg.height);
+        auto                               image_size = image_decoded->get_image_size();
+        shared_ptr<augment::image::params> params =
+            factory.make_params(image_size.width, image_size.height, cfg.width, cfg.height);
 
         localization::extractor   extractor{cfg};
         localization::transformer transformer{cfg, factory.fixed_scaling_factor};
@@ -958,21 +947,19 @@ TEST(localization, loader)
         59099, 59120, 59161, 59182, 59244, 62573, 62574, 62635, 62636, 62697, 62698, 62759, 62760,
         62821, 62822, 62883, 63155, 63156};
 
-    string                    data         = read_file(CURDIR "/test_data/006637.json");
-    int width = 1000;
-    int height = 1000;
+    string         data     = read_file(CURDIR "/test_data/006637.json");
+    int            width    = 1000;
+    int            height   = 1000;
     nlohmann::json js_image = {{"width", width}, {"height", height}, {"channels", 3}};
-    nlohmann::json js_loc = {{"width", width},
-                            {"height", height},
-                            {"class_names", label_list},
-                            {"max_gt_boxes", 64}};
+    nlohmann::json js_loc   = {
+        {"width", width}, {"height", height}, {"class_names", label_list}, {"max_gt_boxes", 64}};
     nlohmann::json js_aug = {{"type", "image"},
-                               {"flip_enable", false},
-                               {"crop_enable", false},
-                               {"fixed_aspect_ratio", true},
-                               {"fixed_scaling_factor", 1.6}};
-    image::config image_config{js_image};
-    localization::config cfg{js_loc};
+                             {"flip_enable", false},
+                             {"crop_enable", false},
+                             {"fixed_aspect_ratio", true},
+                             {"fixed_scaling_factor", 1.6}};
+    image::config                 image_config{js_image};
+    localization::config          cfg{js_loc};
     augment::image::param_factory factory(js_aug);
 
     localization::extractor   extractor{cfg};
@@ -981,12 +968,13 @@ TEST(localization, loader)
     auto                      extract_data = extractor.extract(&data[0], data.size());
     ASSERT_NE(nullptr, extract_data);
 
-    vector<unsigned char>      img = make_image_from_metadata(data);
-    image::extractor           ext{image_config};
-    shared_ptr<image::decoded> decoded = ext.extract((char*)&img[0], img.size());
-    auto image_size = decoded->get_image_size();
-    shared_ptr<augment::image::params>  params = factory.make_params(image_size.width, image_size.height, cfg.width, cfg.height);
-    params->debug_deterministic       = true;
+    vector<unsigned char>              img = make_image_from_metadata(data);
+    image::extractor                   ext{image_config};
+    shared_ptr<image::decoded>         decoded    = ext.extract((char*)&img[0], img.size());
+    auto                               image_size = decoded->get_image_size();
+    shared_ptr<augment::image::params> params =
+        factory.make_params(image_size.width, image_size.height, cfg.width, cfg.height);
+    params->debug_deterministic = true;
 
     shared_ptr<localization::decoded> transformed_data =
         transformer.transform(params, extract_data);
@@ -1155,20 +1143,16 @@ TEST(localization, loader)
 
 TEST(localization, loader_zero_gt_boxes)
 {
-    string data = read_file(CURDIR "/test_data/006637.json");
-    int width = 1000;
-    int height = 1000;
+    string data   = read_file(CURDIR "/test_data/006637.json");
+    int    width  = 1000;
+    int    height = 1000;
 
     nlohmann::json js_image = {{"width", width}, {"height", height}, {"channels", 3}};
-    nlohmann::json js_loc = {{"width", width},
-                             {"height", height},
-                             {"class_names", label_list},
-                             {"max_gt_boxes", 64}};
-    nlohmann::json js_aug = {{"type", "image"},
-                             {"flip_enable", false},
-                             {"scale", {0.1, 0.1}}};
-    image::config image_config{js_image};
-    localization::config cfg{js_loc};
+    nlohmann::json js_loc   = {
+        {"width", width}, {"height", height}, {"class_names", label_list}, {"max_gt_boxes", 64}};
+    nlohmann::json js_aug = {{"type", "image"}, {"flip_enable", false}, {"scale", {0.1, 0.1}}};
+    image::config  image_config{js_image};
+    localization::config          cfg{js_loc};
     augment::image::param_factory factory(js_aug);
 
     localization::extractor   extractor{cfg};
@@ -1177,14 +1161,15 @@ TEST(localization, loader_zero_gt_boxes)
     auto                      extract_data = extractor.extract(&data[0], data.size());
     ASSERT_NE(nullptr, extract_data);
 
-    vector<unsigned char>      img = make_image_from_metadata(data);
-    image::extractor           ext{image_config};
-    shared_ptr<image::decoded> decoded = ext.extract((char*)&img[0], img.size());
-    auto image_size = decoded->get_image_size();
-    shared_ptr<augment::image::params>  params = factory.make_params(image_size.width, image_size.height, cfg.width, cfg.height);
-    params->debug_deterministic       = true;
-    params->cropbox.x                 = 0;
-    params->cropbox.y                 = 0;
+    vector<unsigned char>              img = make_image_from_metadata(data);
+    image::extractor                   ext{image_config};
+    shared_ptr<image::decoded>         decoded    = ext.extract((char*)&img[0], img.size());
+    auto                               image_size = decoded->get_image_size();
+    shared_ptr<augment::image::params> params =
+        factory.make_params(image_size.width, image_size.height, cfg.width, cfg.height);
+    params->debug_deterministic = true;
+    params->cropbox.x           = 0;
+    params->cropbox.y           = 0;
 
     shared_ptr<localization::decoded> transformed_data =
         transformer.transform(params, extract_data);
@@ -1317,28 +1302,23 @@ TEST(localization, compute_targets)
 
 TEST(localization, provider)
 {
-    int height = 1000;
-    int width = 1000;
+    int   height               = 1000;
+    int   width                = 1000;
     float fixed_scaling_factor = 1.6;
 
-    nlohmann::json js_image = {{"type", "image"},
-                               {"height", height},
-                               {"width", width},
-                               {"channel_major", false}};
+    nlohmann::json js_image = {
+        {"type", "image"}, {"height", height}, {"width", width}, {"channel_major", false}};
     nlohmann::json js_local = {{"type", "localization"},
                                {"height", height},
-                               {"width", width}, 
-                               {"max_gt_boxes", 64}, 
+                               {"width", width},
+                               {"max_gt_boxes", 64},
                                {"class_names", {"bicycle", "person"}}};
     nlohmann::json augmentation = {{"type", "image"},
                                    {"fixed_aspect_ratio", true},
                                    {"fixed_scaling_factor", fixed_scaling_factor},
                                    {"crop_enable", false},
                                    {"flip_enable", true}};
-    nlohmann::json js = {
-                         {"etl", {js_image, js_local}},
-                         {"augmentation", {augmentation}}
-                         };
+    nlohmann::json js = {{"etl", {js_image, js_local}}, {"augmentation", {augmentation}}};
 
     shared_ptr<provider_interface> media   = provider_factory::create(js);
     auto                           oshapes = media->get_output_shapes();
@@ -1370,9 +1350,9 @@ TEST(localization, provider)
 
     media->provide(0, in_buf, out_buf);
 
-    int     output_width    = image_shape.get_shape()[0];
-    int     output_height   = image_shape.get_shape()[1];
-    int     channels = image_shape.get_shape()[2];
+    int     output_width  = image_shape.get_shape()[0];
+    int     output_height = image_shape.get_shape()[1];
+    int     channels      = image_shape.get_shape()[2];
     cv::Mat result(output_height, output_width, CV_8UC(channels), out_buf["image"]->get_item(0));
     //    cv::imwrite("localization_provider_source.png", image);
     //    cv::imwrite("localization_provider.png", result);
@@ -1401,28 +1381,23 @@ TEST(localization, provider)
 
 TEST(localization, provider_channel_major)
 {
-    int height = 1000;
-    int width = 1000;
+    int   height               = 1000;
+    int   width                = 1000;
     float fixed_scaling_factor = 1.6;
 
-
-     nlohmann::json js_image = {{"type", "image"},
-                           {"height", height},
-                           {"width", width},
-                           {"channel_major", true}};
+    nlohmann::json js_image = {
+        {"type", "image"}, {"height", height}, {"width", width}, {"channel_major", true}};
     nlohmann::json js_loc = {{"type", "localization"},
-                           {"height", height},
-                           {"width", width}, 
-                           {"max_gt_boxes", 64}, 
-                           {"class_names", {"bicycle", "person"}}};
+                             {"height", height},
+                             {"width", width},
+                             {"max_gt_boxes", 64},
+                             {"class_names", {"bicycle", "person"}}};
     nlohmann::json js_aug = {{"type", "image"},
-                            {"crop_enable", false},
-                            {"fixed_aspect_ratio", true},
-                            {"fixed_scaling_factor", fixed_scaling_factor}, 
-                            {"flip_enable", true}};
-     nlohmann::json js = {
-                         {"etl", {js_image, js_loc}},
-                         {"augmentation", {js_aug}}};
+                             {"crop_enable", false},
+                             {"fixed_aspect_ratio", true},
+                             {"fixed_scaling_factor", fixed_scaling_factor},
+                             {"flip_enable", true}};
+    nlohmann::json js = {{"etl", {js_image, js_loc}}, {"augmentation", {js_aug}}};
 
     auto media   = provider_factory::create(js);
     auto oshapes = media->get_output_shapes();

--- a/test/test_manifest_csv.cpp
+++ b/test/test_manifest_csv.cpp
@@ -444,7 +444,7 @@ TEST(manifest, ascii_int)
     {
         for (int i = 0; i < image_files.size(); i++)
         {
-            ss << image_files[i] << "\t" << count*2+i << "\n";
+            ss << image_files[i] << "\t" << count * 2 + i << "\n";
         }
     }
 
@@ -465,9 +465,9 @@ TEST(manifest, ascii_int)
         ASSERT_EQ(block_size, buffer->size());
         for (int j = 0; j < buffer->size(); j++)
         {
-            encoded_record record   = buffer->record(j);
-            auto           idata    = record.element(0);
-            int32_t        tdata    = unpack<int32_t>(record.element(1).data());
+            encoded_record record = buffer->record(j);
+            auto           idata  = record.element(0);
+            int32_t        tdata  = unpack<int32_t>(record.element(1).data());
             EXPECT_EQ(tdata, index);
             index++;
         }
@@ -487,7 +487,7 @@ TEST(manifest, ascii_float)
     {
         for (int i = 0; i < image_files.size(); i++)
         {
-            ss << image_files[i] << "\t" << (float)(count*2+i)/10. << "\n";
+            ss << image_files[i] << "\t" << (float)(count * 2 + i) / 10. << "\n";
         }
     }
 
@@ -511,7 +511,7 @@ TEST(manifest, ascii_float)
             encoded_record record   = buffer->record(j);
             auto           idata    = record.element(0);
             float          tdata    = unpack<float>(record.element(1).data());
-            float expected = (float)index/10.;
+            float          expected = (float)index / 10.;
             EXPECT_EQ(tdata, expected);
             index++;
         }
@@ -630,27 +630,25 @@ TEST(manifest, crc_root_dir)
 {
     stringstream ss;
     ss << manifest_file::get_metadata_char();
-    ss << manifest_file::get_file_type_id() << manifest_file::get_delimiter() << manifest_file::get_string_type_id() << "\n";
-    for (size_t i=0; i<100; i++)
+    ss << manifest_file::get_file_type_id() << manifest_file::get_delimiter()
+       << manifest_file::get_string_type_id() << "\n";
+    for (size_t i = 0; i < 100; i++)
     {
-        ss << "relative/path/image" << i << ".jpg" << manifest_file::get_delimiter() << i << "\n"; 
+        ss << "relative/path/image" << i << ".jpg" << manifest_file::get_delimiter() << i << "\n";
     }
 
     uint32_t manifest1_crc;
     uint32_t manifest2_crc;
 
-    float  subset_fraction  = 1.0;
-    int    block_size       = 4;
-    bool   shuffle_manifest = false;
+    float subset_fraction  = 1.0;
+    int   block_size       = 4;
+    bool  shuffle_manifest = false;
 
     {
         stringstream tmp{ss.str()};
-        string manifest_root = "/root1/";
-        auto manifest = make_shared<nervana::manifest_file>(tmp,
-                                                            shuffle_manifest,
-                                                            manifest_root,
-                                                            subset_fraction,
-                                                            block_size);
+        string       manifest_root = "/root1/";
+        auto         manifest      = make_shared<nervana::manifest_file>(
+            tmp, shuffle_manifest, manifest_root, subset_fraction, block_size);
 
         ASSERT_NE(nullptr, manifest);
 
@@ -659,12 +657,9 @@ TEST(manifest, crc_root_dir)
 
     {
         stringstream tmp{ss.str()};
-        string manifest_root = "/root2/";
-        auto manifest = make_shared<nervana::manifest_file>(tmp,
-                                                            shuffle_manifest,
-                                                            manifest_root,
-                                                            subset_fraction,
-                                                            block_size);
+        string       manifest_root = "/root2/";
+        auto         manifest      = make_shared<nervana::manifest_file>(
+            tmp, shuffle_manifest, manifest_root, subset_fraction, block_size);
 
         ASSERT_NE(nullptr, manifest);
 
@@ -676,43 +671,48 @@ TEST(manifest, crc_root_dir)
 
 TEST(benchmark, manifest)
 {
-   string manifest_filename = file_util::tmp_filename();
-   string cache_root = "/this/is/supposed/to/be/long/so/we/make/it/so/";
-   cout << "tmp manifest file " << manifest_filename << endl;
+    string manifest_filename = file_util::tmp_filename();
+    string cache_root        = "/this/is/supposed/to/be/long/so/we/make/it/so/";
+    cout << "tmp manifest file " << manifest_filename << endl;
 
-   chrono::high_resolution_clock timer;
+    chrono::high_resolution_clock timer;
 
-   // Generate a manifest file
-   {
-       auto startTime = timer.now();
-       ofstream mfile(manifest_filename);
-       for(int i=0; i<10e6; i++)
-       {
-           mfile << cache_root << "image_" << i << ".jpg,";
-           mfile << cache_root << "target_" << i << ".txt\n";
-       }
-       auto endTime = timer.now();
-       cout << "create manifest " << (chrono::duration_cast<chrono::milliseconds>(endTime - startTime)).count()  << " ms" <<
-       endl;
-   }
+    // Generate a manifest file
+    {
+        auto     startTime = timer.now();
+        ofstream mfile(manifest_filename);
+        for (int i = 0; i < 10e6; i++)
+        {
+            mfile << cache_root << "image_" << i << ".jpg,";
+            mfile << cache_root << "target_" << i << ".txt\n";
+        }
+        auto endTime = timer.now();
+        cout << "create manifest "
+             << (chrono::duration_cast<chrono::milliseconds>(endTime - startTime)).count() << " ms"
+             << endl;
+    }
 
-   // Parse the manifest file
-   shared_ptr<manifest_file> manifest;
-   {
-       auto startTime = timer.now();
-       manifest = make_shared<manifest_file>(manifest_filename, false);
-       auto endTime = timer.now();
-       cout << "load manifest " << (chrono::duration_cast<chrono::milliseconds>(endTime - startTime)).count()  << " ms" << endl;
-   }
+    // Parse the manifest file
+    shared_ptr<manifest_file> manifest;
+    {
+        auto startTime = timer.now();
+        manifest       = make_shared<manifest_file>(manifest_filename, false);
+        auto endTime   = timer.now();
+        cout << "load manifest "
+             << (chrono::duration_cast<chrono::milliseconds>(endTime - startTime)).count() << " ms"
+             << endl;
+    }
 
-   // compute the CRC
-   {
-       auto startTime = timer.now();
-       uint32_t crc = manifest->get_crc();
-       auto endTime = timer.now();
-       cout << "manifest crc 0x" << setfill('0') << setw(8) << hex << crc << dec << endl;
-       cout << "crc time " << (chrono::duration_cast<chrono::milliseconds>(endTime - startTime)).count()  << " ms" << endl;
-   }
+    // compute the CRC
+    {
+        auto     startTime = timer.now();
+        uint32_t crc       = manifest->get_crc();
+        auto     endTime   = timer.now();
+        cout << "manifest crc 0x" << setfill('0') << setw(8) << hex << crc << dec << endl;
+        cout << "crc time "
+             << (chrono::duration_cast<chrono::milliseconds>(endTime - startTime)).count() << " ms"
+             << endl;
+    }
 
-   remove(manifest_filename.c_str());
+    remove(manifest_filename.c_str());
 }

--- a/test/test_pixel_mask.cpp
+++ b/test/test_pixel_mask.cpp
@@ -83,17 +83,18 @@ TEST(pixel_mask, scale_up)
     nlohmann::json aug;
     image::config  cfg(js);
 
-    pixel_mask::extractor   extractor{cfg};
-    pixel_mask::transformer transformer{cfg};
-    image::loader           loader{cfg, false};
-    augment::image::param_factory    factory{aug};
+    pixel_mask::extractor         extractor{cfg};
+    pixel_mask::transformer       transformer{cfg};
+    image::loader                 loader{cfg, false};
+    augment::image::param_factory factory{aug};
 
-    auto extracted = extractor.extract((const char*)test_data.data(), test_data.size());
+    auto extracted  = extractor.extract((const char*)test_data.data(), test_data.size());
     auto image_size = extracted->get_image_size();
-    image_params_builder       builder(factory.make_params(image_size.width, image_size.height, cfg.width, cfg.height));
-    shared_ptr<augment::image::params>  params_ptr  = builder.output_size(300, 300);
-    shared_ptr<image::decoded> transformed = transformer.transform(params_ptr, extracted);
-    cv::Mat                    tximg       = transformed->get_image(0);
+    image_params_builder builder(
+        factory.make_params(image_size.width, image_size.height, cfg.width, cfg.height));
+    shared_ptr<augment::image::params> params_ptr  = builder.output_size(300, 300);
+    shared_ptr<image::decoded>         transformed = transformer.transform(params_ptr, extracted);
+    cv::Mat                            tximg       = transformed->get_image(0);
     cv::imwrite("tx_pixel_mask_scale_up.png", tximg);
     EXPECT_TRUE(verify_image(tximg));
 }
@@ -109,17 +110,18 @@ TEST(pixel_mask, scale_down)
     nlohmann::json aug;
     image::config  cfg(js);
 
-    pixel_mask::extractor   extractor{cfg};
-    pixel_mask::transformer transformer{cfg};
-    image::loader           loader{cfg, false};
-    augment::image::param_factory    factory{aug};
+    pixel_mask::extractor         extractor{cfg};
+    pixel_mask::transformer       transformer{cfg};
+    image::loader                 loader{cfg, false};
+    augment::image::param_factory factory{aug};
 
-    auto extracted = extractor.extract((const char*)test_data.data(), test_data.size());
+    auto extracted  = extractor.extract((const char*)test_data.data(), test_data.size());
     auto image_size = extracted->get_image_size();
-    image_params_builder       builder(factory.make_params(image_size.width, image_size.height, cfg.width, cfg.height));
-    shared_ptr<augment::image::params>  params_ptr  = builder.output_size(100, 100);
-    shared_ptr<image::decoded> transformed = transformer.transform(params_ptr, extracted);
-    cv::Mat                    tximg       = transformed->get_image(0);
+    image_params_builder builder(
+        factory.make_params(image_size.width, image_size.height, cfg.width, cfg.height));
+    shared_ptr<augment::image::params> params_ptr  = builder.output_size(100, 100);
+    shared_ptr<image::decoded>         transformed = transformer.transform(params_ptr, extracted);
+    cv::Mat                            tximg       = transformed->get_image(0);
     cv::imwrite("tx_pixel_mask_scale_down.png", tximg);
     EXPECT_TRUE(verify_image(tximg));
 }
@@ -135,17 +137,18 @@ TEST(pixel_mask, rotate)
     nlohmann::json aug;
     image::config  cfg(js);
 
-    pixel_mask::extractor   extractor{cfg};
-    pixel_mask::transformer transformer{cfg};
-    image::loader           loader{cfg, false};
-    augment::image::param_factory    factory{aug};
+    pixel_mask::extractor         extractor{cfg};
+    pixel_mask::transformer       transformer{cfg};
+    image::loader                 loader{cfg, false};
+    augment::image::param_factory factory{aug};
 
-    auto extracted = extractor.extract((const char*)test_data.data(), test_data.size());
+    auto extracted  = extractor.extract((const char*)test_data.data(), test_data.size());
     auto image_size = extracted->get_image_size();
-    image_params_builder       builder(factory.make_params(image_size.width, image_size.height, cfg.width, cfg.height));
-    shared_ptr<augment::image::params>  params_ptr  = builder.angle(45);
-    shared_ptr<image::decoded> transformed = transformer.transform(params_ptr, extracted);
-    cv::Mat                    tximg       = transformed->get_image(0);
+    image_params_builder builder(
+        factory.make_params(image_size.width, image_size.height, cfg.width, cfg.height));
+    shared_ptr<augment::image::params> params_ptr  = builder.angle(45);
+    shared_ptr<image::decoded>         transformed = transformer.transform(params_ptr, extracted);
+    cv::Mat                            tximg       = transformed->get_image(0);
     cv::imwrite("tx_pixel_mask_rotate.png", tximg);
     EXPECT_TRUE(verify_image(tximg));
 }
@@ -172,32 +175,33 @@ TEST(pixel_mask, load_int)
     nlohmann::json js = {
         {"width", 256}, {"height", 256}, {"output_type", "int32_t"}, {"channels", 1}};
     nlohmann::json aug;
-    image::config cfg(js);
+    image::config  cfg(js);
 
-    pixel_mask::extractor   extractor{cfg};
-    pixel_mask::transformer transformer{cfg};
-    image::loader           loader{cfg, false};
-    augment::image::param_factory    factory{aug};
+    pixel_mask::extractor         extractor{cfg};
+    pixel_mask::transformer       transformer{cfg};
+    image::loader                 loader{cfg, false};
+    augment::image::param_factory factory{aug};
 
-    auto extracted = extractor.extract((const char*)test_data.data(), test_data.size());
+    auto extracted  = extractor.extract((const char*)test_data.data(), test_data.size());
     auto image_size = extracted->get_image_size();
-    image_params_builder       builder(factory.make_params(image_size.width, image_size.height, cfg.width, cfg.height));
-    shared_ptr<augment::image::params>  params_ptr  = builder;
-    shared_ptr<image::decoded> transformed = transformer.transform(params_ptr, extracted);
-    cv::Mat                    tximg       = transformed->get_image(0);
+    image_params_builder builder(
+        factory.make_params(image_size.width, image_size.height, cfg.width, cfg.height));
+    shared_ptr<augment::image::params> params_ptr  = builder;
+    shared_ptr<image::decoded>         transformed = transformer.transform(params_ptr, extracted);
+    cv::Mat                            tximg       = transformed->get_image(0);
 
     cv::Mat output_image(256, 256, CV_32SC1);
     loader.load({output_image.data}, transformed);
 
     {
         uint8_t* output = output_image.data;
-        index  = 0;
+        index           = 0;
         for (int row = 0; row < 256; row++)
         {
             for (int col = 0; col < 256; col++)
             {
                 uint8_t value = col;
-                ASSERT_EQ(value, unpack<int32_t>(&output[sizeof(int32_t)*index++]));
+                ASSERT_EQ(value, unpack<int32_t>(&output[sizeof(int32_t) * index++]));
             }
         }
     }

--- a/test/test_provider_audio.cpp
+++ b/test/test_provider_audio.cpp
@@ -31,14 +31,13 @@ using namespace nervana;
 
 TEST(provider, audio_classify)
 {
-    nlohmann::json js_label = {{"type", "label"},
-                           {"binary", true}};
+    nlohmann::json js_label = {{"type", "label"}, {"binary", true}};
     nlohmann::json js_audio = {{"type", "audio"},
-                           {"max_duration", "2000 milliseconds"},
-                           {"frame_length", "1024 samples"},
-                           {"frame_stride", "256 samples"},
-                           {"sample_freq_hz", 44100},
-                           {"feature_type", "specgram"}};
+                               {"max_duration", "2000 milliseconds"},
+                               {"frame_length", "1024 samples"},
+                               {"frame_stride", "256 samples"},
+                               {"sample_freq_hz", 44100},
+                               {"feature_type", "specgram"}};
     nlohmann::json js = {{"etl", {js_audio, js_label}}};
 
     auto media   = nervana::provider_factory::create(js);
@@ -82,20 +81,18 @@ TEST(provider, audio_classify)
     }
 }
 
-
 TEST(provider, transcript_length_check)
 {
-    uint32_t       max_length = 15;
-    nlohmann::json js_transcript    = {
-        {"type", "char_map"},
-        {"alphabet", "abcdefgß "},
-        {"max_length", max_length},
-        {"emit_length", true}};
+    uint32_t       max_length    = 15;
+    nlohmann::json js_transcript = {{"type", "char_map"},
+                                    {"alphabet", "abcdefgß "},
+                                    {"max_length", max_length},
+                                    {"emit_length", true}};
 
     nlohmann::json js = {{"etl", {js_transcript}}};
 
-    auto media   = nervana::provider_factory::create(js);
-    auto oshapes = media->get_output_shapes();
+    auto media     = nervana::provider_factory::create(js);
+    auto oshapes   = media->get_output_shapes();
     auto buf_names = media->get_buffer_names();
 
     // Ensure that we have two output buffers (an extra one for the transcript length since emit_length == true)
@@ -105,16 +102,12 @@ TEST(provider, transcript_length_check)
 
     size_t batch_size = 4;
 
-    fixed_buffer_map    out_buf(oshapes, batch_size);
-    encoded_record_list bp;
-    std::vector<string> transcripts{"abcß", "ßßad", "abcabc", "ddefggf"};
-    std::vector<uint32_t> expected_lengths{4, 4, 6, 7};
+    fixed_buffer_map                   out_buf(oshapes, batch_size);
+    encoded_record_list                bp;
+    std::vector<string>                transcripts{"abcß", "ßßad", "abcabc", "ddefggf"};
+    std::vector<uint32_t>              expected_lengths{4, 4, 6, 7};
     std::vector<std::vector<uint32_t>> expected_encodings{
-        {0, 1, 2, 7},
-        {7, 7, 0, 3},
-        {0, 1, 2, 0, 1, 2},
-        {3, 3, 4, 5, 6, 6, 5}
-    };
+        {0, 1, 2, 7}, {7, 7, 0, 3}, {0, 1, 2, 0, 1, 2}, {3, 3, 4, 5, 6, 6, 5}};
     for (auto&& s : transcripts)
     {
         encoded_record record;
@@ -138,7 +131,7 @@ TEST(provider, transcript_length_check)
 
     for (int i = 0; i < batch_size; i++)
     {
-        uint32_t* loaded_transcript = (uint32_t*) out_buf["char_map"]->get_item(i);
+        uint32_t* loaded_transcript = (uint32_t*)out_buf["char_map"]->get_item(i);
 
         for (uint32_t j = 0; j < max_length; ++j)
         {
@@ -150,7 +143,6 @@ TEST(provider, transcript_length_check)
             {
                 EXPECT_EQ(loaded_transcript[j], 0);
             }
-
         }
     }
 }

--- a/test/test_raw_image.cpp
+++ b/test/test_raw_image.cpp
@@ -45,7 +45,7 @@ TEST(raw_image, write_read)
     string file = "raw.bin";
 
     {
-        auto   mat  = generate_indexed_image();
+        auto mat = generate_indexed_image();
         auto raw = raw_image::from_cvmat(mat);
         raw.write(file);
     }

--- a/test/test_util.cpp
+++ b/test/test_util.cpp
@@ -46,7 +46,7 @@
 using namespace std;
 using namespace nervana;
 
-template<typename T>
+template <typename T>
 static T setup(initializer_list<uint8_t> data)
 {
     T        rc;
@@ -130,7 +130,7 @@ TEST(util, pack_le)
 {
     {
         uint32_t actual;
-        auto expected = setup<uint32_t>({1, 0, 0, 0});
+        auto     expected = setup<uint32_t>({1, 0, 0, 0});
         pack<uint32_t>(&actual, 1);
         EXPECT_EQ(expected, actual);
     }

--- a/test/test_video.cpp
+++ b/test/test_video.cpp
@@ -60,10 +60,11 @@ TEST(video, extract_transform)
         // transform
         video::transformer transformer = video::transformer(config);
 
-        nlohmann::json aug;
+        nlohmann::json                aug;
         augment::image::param_factory factory(aug);
-        auto image_size = decoded_vid->get_image_size();
-        auto                 params = factory.make_params(image_size.width, image_size.height, config.frame.width, config.frame.height);
+        auto                          image_size = decoded_vid->get_image_size();
+        auto                          params     = factory.make_params(
+            image_size.width, image_size.height, config.frame.width, config.frame.height);
 
         params->output_size  = cv::Size2i(width / 2, height / 2);
         auto transformed_vid = transformer.transform(params, decoded_vid);
@@ -98,9 +99,10 @@ TEST(video, image_transform)
     image::transformer _imageTransformer(config);
 
     augment::image::param_factory factory(aug);
-    auto image_size = decoded_image->get_image_size();
-    auto                 imageParams = factory.make_params(image_size.width, image_size.height, config.width, config.height);
-    imageParams->output_size         = cv::Size2i(width / 2, height / 2);
+    auto                          image_size = decoded_image->get_image_size();
+    auto                          imageParams =
+        factory.make_params(image_size.width, image_size.height, config.width, config.height);
+    imageParams->output_size = cv::Size2i(width / 2, height / 2);
 
     _imageTransformer.transform(imageParams, decoded_image);
 }


### PR DESCRIPTION
This adds a configuration option `emit_length` to `char_map` such that an additional output buffer will be created giving the valid length of each character sequence.  This is useful for post-processing a sequence buffer for ctc.  

I also added some tests to do end-to-end provision of a unicode character string as it might be encountered in a manifest file.
