### PR TITLE
Fix for configure error caused by 'Could NOT find Sphinx (missing:  S…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,5 @@ pillow==3.3.1
 numpy==1.13.1
 pytest==3.0.1
 pytest-cov==2.3.1
+sphinx==1.6.5
 future


### PR DESCRIPTION
…PHINX_VERSION)'