### PR TITLE
patch forcing matching version of PythonInterp and PythonLibs to 2.7

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -148,10 +148,10 @@ find_package(CURL REQUIRED)
 include_directories(${CURL_INCLUDE_DIRS})
 link_directories(${CURL_LIBRARY_DIRS})
 
-set(Python_ADDITIONAL_VERSIONS 3.6 3.5 3.4)
+# set(Python_ADDITIONAL_VERSIONS 3.6 3.5 3.4)
 
-find_package(PythonLibs)
 find_package(PythonInterp)
+find_package(PythonLibs)
 
 if (PYTHON_PLUGIN)
     if (NOT ${PYTHON_VERISON_MAJOR} EQUAL ${OpenCV_VERSION_MAJOR})


### PR DESCRIPTION
The instruction for integratin aeon with ngraph-paddle is complex and involved applying this patch. Please consider merging it until a better solution is found.