### PR TITLE
add env var AEON_CPU_LIST  & config attr cpu_list which control cpu affinity

### DIFF
--- a/doc/source/user_guide.rst
+++ b/doc/source/user_guide.rst
@@ -186,7 +186,7 @@ The possible base loader configurations are the following (configurations withou
    subset_fraction (float)| 1.0 | Fraction of the dataset to iterate over. Useful when testing code on smaller data samples.
    shuffle_enable (bool) | False | Shuffles the dataset order for every epoch
    shuffle_manifest (bool) | False | Shuffles manifest file contents
-   cpu_list (string) | "" | Controls number of decoding threads and their core affinity. If unset, Aeon automatically chooses number of threads to logical number of cores diminished by two and allocates them on cores from 0 to num_logical_cores-2. Cores can be specified by numbers and ranges starting at 0 as follows `AEON_CPU_LIST=0-5,20,10,32-34`.
+   cpu_list (string) | "" | Controls number of decoding threads and their core affinity. If unset, Aeon automatically chooses number of threads to logical number of cores diminished by two and allocates them on cores from 0 to num_logical_cores-2. Cores can be specified as comma separated list of both numbers and ranges. Core indexing start from 0. For example: `0-5,20,10,32-34`.
    pinned (bool)| False |
    random_seed (uint)| 0 | Set not a zero value if you need to have deterministic output. In that case aeon will always produce the same output for given a particular input.
    iteration_mode (string)|"ONCE"| Can be "ONCE", "COUNT", or "INFINITE"
@@ -195,7 +195,7 @@ The possible base loader configurations are the following (configurations withou
    augmentation||
    remote|| Configuration of connection with aeon service in distrubted dataloading scenario. Please take a look at :doc:`service <service>` documentation.
 
-Aeon also supports an environment variable ``AEON_CPU_LIST`` which overrides `cpu_list`. 
+Aeon also supports an environment variable ``AEON_CPU_LIST`` which overrides `cpu_list`.
 
 Example python usage
 --------------------

--- a/doc/source/user_guide.rst
+++ b/doc/source/user_guide.rst
@@ -186,7 +186,7 @@ The possible base loader configurations are the following (configurations withou
    subset_fraction (float)| 1.0 | Fraction of the dataset to iterate over. Useful when testing code on smaller data samples.
    shuffle_enable (bool) | False | Shuffles the dataset order for every epoch
    shuffle_manifest (bool) | False | Shuffles manifest file contents
-   decode_thread_count (int)| 0 | Number of threads to use. If default value 0 is set, Aeon automatically chooses number of threads to logical number of cores diminished by two. To execute on a single thread, use value of 1
+   cpu_list (string) | "" | Controls number of decoding threads and their core affinity. If unset, Aeon automatically chooses number of threads to logical number of cores diminished by two and allocates them on cores from 0 to num_logical_cores-2. Cores can be specified by numbers and ranges starting at 0 as follows `AEON_CPU_LIST=0-5,20,10,32-34`.
    pinned (bool)| False |
    random_seed (uint)| 0 | Set not a zero value if you need to have deterministic output. In that case aeon will always produce the same output for given a particular input.
    iteration_mode (string)|"ONCE"| Can be "ONCE", "COUNT", or "INFINITE"
@@ -194,6 +194,8 @@ The possible base loader configurations are the following (configurations withou
    etl||
    augmentation||
    remote|| Configuration of connection with aeon service in distrubted dataloading scenario. Please take a look at :doc:`service <service>` documentation.
+
+Aeon also supports an environment variable ``AEON_CPU_LIST`` which overrides `cpu_list`. 
 
 Example python usage
 --------------------

--- a/src/batch_decoder.cpp
+++ b/src/batch_decoder.cpp
@@ -23,7 +23,7 @@ using namespace nervana;
 
 batch_decoder::batch_decoder(shared_ptr<batch_iterator>                 b_itor,
                              size_t                                     batch_size,
-                             std::vector<int>                           thread_affinity_map,
+                             const std::vector<int>&                    thread_affinity_map,
                              bool                                       pinned,
                              const std::shared_ptr<provider_interface>& prov,
                              uint32_t                                   seed)

--- a/src/batch_decoder.cpp
+++ b/src/batch_decoder.cpp
@@ -23,7 +23,7 @@ using namespace nervana;
 
 batch_decoder::batch_decoder(shared_ptr<batch_iterator>                 b_itor,
                              size_t                                     batch_size,
-                             const std::vector<int>&                    thread_affinity_map,
+                             std::vector<int>                           thread_affinity_map,
                              bool                                       pinned,
                              const std::shared_ptr<provider_interface>& prov,
                              uint32_t                                   seed)
@@ -33,7 +33,7 @@ batch_decoder::batch_decoder(shared_ptr<batch_iterator>                 b_itor,
     , m_deterministic_mode(seed != 0)
 {
     m_thread_pool = singleton<thread_pool_queue<batch_decoder, &batch_decoder::process>>::get(
-        thread_affinity_map);
+        std::move(thread_affinity_map));
     m_number_elements_in = prov->get_input_count();
 
     // Allocate the space in the output buffers

--- a/src/batch_decoder.cpp
+++ b/src/batch_decoder.cpp
@@ -23,7 +23,7 @@ using namespace nervana;
 
 batch_decoder::batch_decoder(shared_ptr<batch_iterator>                 b_itor,
                              size_t                                     batch_size,
-                             uint32_t                                   thread_count,
+                             std::vector<int>                           thread_affinity_map,
                              bool                                       pinned,
                              const std::shared_ptr<provider_interface>& prov,
                              uint32_t                                   seed)
@@ -32,8 +32,8 @@ batch_decoder::batch_decoder(shared_ptr<batch_iterator>                 b_itor,
     , m_provider(prov)
     , m_deterministic_mode(seed != 0)
 {
-    m_thread_pool =
-        singleton<thread_pool_queue<batch_decoder, &batch_decoder::process>>::get(thread_count);
+    m_thread_pool = singleton<thread_pool_queue<batch_decoder, &batch_decoder::process>>::get(
+        thread_affinity_map);
     m_number_elements_in = prov->get_input_count();
 
     // Allocate the space in the output buffers
@@ -44,7 +44,9 @@ batch_decoder::batch_decoder(shared_ptr<batch_iterator>                 b_itor,
     {
         m_random.resize(batch_size);
         random_engine_t generator_seed(seed);
-        for_each(m_random.begin(), m_random.end(), [&](random_engine_t& eng) { eng.seed(generator_seed()); });
+        for_each(m_random.begin(), m_random.end(), [&](random_engine_t& eng) {
+            eng.seed(generator_seed());
+        });
     }
 }
 

--- a/src/batch_decoder.hpp
+++ b/src/batch_decoder.hpp
@@ -33,7 +33,7 @@ class nervana::batch_decoder : public async_manager<encoded_record_list, fixed_b
 public:
     batch_decoder(std::shared_ptr<batch_iterator>            b_itor,
                   size_t                                     batch_size,
-                  uint32_t                                   thread_count,
+                  std::vector<int>                           thread_affinity_map,
                   bool                                       pinned,
                   const std::shared_ptr<provider_interface>& prov,
                   uint32_t                                   seed = 0);

--- a/src/batch_decoder.hpp
+++ b/src/batch_decoder.hpp
@@ -33,7 +33,7 @@ class nervana::batch_decoder : public async_manager<encoded_record_list, fixed_b
 public:
     batch_decoder(std::shared_ptr<batch_iterator>            b_itor,
                   size_t                                     batch_size,
-                  std::vector<int>                           thread_affinity_map,
+                  const std::vector<int>&                    thread_affinity_map,
                   bool                                       pinned,
                   const std::shared_ptr<provider_interface>& prov,
                   uint32_t                                   seed = 0);

--- a/src/batch_decoder.hpp
+++ b/src/batch_decoder.hpp
@@ -33,7 +33,7 @@ class nervana::batch_decoder : public async_manager<encoded_record_list, fixed_b
 public:
     batch_decoder(std::shared_ptr<batch_iterator>            b_itor,
                   size_t                                     batch_size,
-                  const std::vector<int>&                    thread_affinity_map,
+                  std::vector<int>                           thread_affinity_map,
                   bool                                       pinned,
                   const std::shared_ptr<provider_interface>& prov,
                   uint32_t                                   seed = 0);
@@ -59,8 +59,8 @@ private:
     encoded_record_list*                      m_inputs{nullptr};
     fixed_buffer_map*                         m_outputs{nullptr};
     std::shared_ptr<thread_pool_queue<batch_decoder, &batch_decoder::process>> m_thread_pool;
-    std::function<void(const fixed_buffer_map*)> m_info_handler;
-    size_t                                       m_iteration_number{0};
-    std::vector<nervana::random_engine_t>        m_random;
-    bool                                         m_deterministic_mode;
+    std::function<void(const fixed_buffer_map*)>                               m_info_handler;
+    size_t                                m_iteration_number{0};
+    std::vector<nervana::random_engine_t> m_random;
+    bool                                  m_deterministic_mode;
 };

--- a/src/loader.cpp
+++ b/src/loader.cpp
@@ -191,7 +191,7 @@ void loader_local::initialize(const json& config_json)
 
     m_decoder = make_shared<batch_decoder>(m_batch_iterator,
                                            decode_size,
-                                           thread_affinity_map,
+                                           std::move(thread_affinity_map),
                                            lcfg.pinned,
                                            m_provider,
                                            lcfg.random_seed);

--- a/src/loader.hpp
+++ b/src/loader.hpp
@@ -64,7 +64,7 @@ public:
     bool                        pinned               = false;
     bool                        batch_major          = true;
     uint32_t                    random_seed          = 0;
-    uint32_t                    decode_thread_count  = 0;
+    std::string                 cpu_list             = "";
     std::string                 iteration_mode       = "ONCE";
     int                         iteration_mode_count = 0;
     uint16_t                    web_server_port      = 0;
@@ -91,7 +91,7 @@ private:
                    [](decltype(subset_fraction) v) { return v <= 1.0f && v >= 0.0f; }),
         ADD_SCALAR(shuffle_enable, mode::OPTIONAL),
         ADD_SCALAR(shuffle_manifest, mode::OPTIONAL),
-        ADD_SCALAR(decode_thread_count, mode::OPTIONAL),
+        ADD_SCALAR(cpu_list, mode::OPTIONAL),
         ADD_SCALAR(pinned, mode::OPTIONAL),
         ADD_SCALAR(random_seed, mode::OPTIONAL),
         ADD_SCALAR(iteration_mode, mode::OPTIONAL),

--- a/src/loader.hpp
+++ b/src/loader.hpp
@@ -256,9 +256,9 @@ private:
     fixed_buffer_map*                                       m_output_buffer_ptr{nullptr};
     nlohmann::json                                          m_current_config;
     std::shared_ptr<web_app>                                m_debug_web_app;
-    const int                                               m_max_count_of_free_threads = 2;
-    const int                                               m_free_threads_ratio        = 8;
 
     // How many times we should increase input data size for decoder
-    const int m_input_multiplier = 8;
+    const int m_input_multiplier          = 8;
+    const int m_max_count_of_free_threads = 2;
+    const int m_free_threads_ratio        = 8;
 };

--- a/src/loader.hpp
+++ b/src/loader.hpp
@@ -68,10 +68,10 @@ public:
     std::string                 iteration_mode       = "ONCE";
     int                         iteration_mode_count = 0;
     uint16_t                    web_server_port      = 0;
-    std::vector<nlohmann::json> etl;
-    std::vector<nlohmann::json> augmentation;
     uint32_t                    node_id              = 0;
     uint32_t                    node_count           = 0;
+    std::vector<nlohmann::json> etl;
+    std::vector<nlohmann::json> augmentation;
 #if defined(ENABLE_AEON_SERVICE)
     nlohmann::json remote;
 #endif
@@ -256,6 +256,8 @@ private:
     fixed_buffer_map*                                       m_output_buffer_ptr{nullptr};
     nlohmann::json                                          m_current_config;
     std::shared_ptr<web_app>                                m_debug_web_app;
+    const int                                               m_max_count_of_free_threads = 2;
+    const int                                               m_free_threads_ratio        = 8;
 
     // How many times we should increase input data size for decoder
     const int m_input_multiplier = 8;

--- a/src/thread_pool.hpp
+++ b/src/thread_pool.hpp
@@ -83,7 +83,7 @@ template <typename T, void (T::*process_func)(int index)>
 class nervana::thread_pool
 {
 public:
-    thread_pool(std::vector<int> thread_affinity_map)
+    thread_pool(const std::vector<int>& thread_affinity_map)
         : m_thread_affinity_map(thread_affinity_map)
     {
         int nthreads = m_thread_affinity_map.size();
@@ -186,7 +186,7 @@ template <typename T, void (T::*process_func)(int index)>
 class nervana::thread_pool_queue
 {
 public:
-    thread_pool_queue(std::vector<int> thread_affinity_map)
+    thread_pool_queue(const std::vector<int>& thread_affinity_map)
         : m_thread_pool(thread_affinity_map)
         , m_thread(&thread_pool_queue::process_tasks, this)
     {

--- a/src/thread_pool.hpp
+++ b/src/thread_pool.hpp
@@ -83,8 +83,8 @@ template <typename T, void (T::*process_func)(int index)>
 class nervana::thread_pool
 {
 public:
-    thread_pool(const std::vector<int>& thread_affinity_map)
-        : m_thread_affinity_map(thread_affinity_map)
+    thread_pool(std::vector<int> thread_affinity_map)
+        : m_thread_affinity_map(std::move(thread_affinity_map))
     {
         int nthreads = m_thread_affinity_map.size();
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -379,15 +379,5 @@ std::vector<int> nervana::parse_cpu_list(const std::string& cpu_list)
                                     std::to_string(std::thread::hardware_concurrency()) + ").");
     }
 
-    // This should never happen, because it throws at stoi() when parsing
-    // if (thread_affinity_map.front() < 0)
-    // {
-    //     throw std::invalid_argument("One or more indexes computed from cpu list '" + cpu_list +
-    //                                 "' are less than '0'. Use values "
-    //                                 "in "
-    //                                 "range <0, " +
-    //                                 std::to_string(std::thread::hardware_concurrency()) + ").");
-    // }
-
     return thread_affinity_map;
 }

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -376,8 +376,8 @@ std::vector<int> nervana::parse_cpu_list(const std::string& cpu_list)
         throw std::invalid_argument("One or more indexes computed from cpu list '" + cpu_list +
                                     "' exceed number of logical cores. Use values "
                                     "in "
-                                    "range <0, " +
-                                    std::to_string(std::thread::hardware_concurrency()) + ").");
+                                    "range [0, " +
+                                    std::to_string(std::thread::hardware_concurrency() - 1) + "].");
     }
 
     return thread_affinity_map;

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -365,7 +365,8 @@ std::vector<int> nervana::parse_cpu_list(const std::string& cpu_list)
     if (ip != thread_affinity_map.end())
     {
         auto num_removed_duplicates = std::distance(ip, thread_affinity_map.end());
-        WARN << "Removed '" << std::to_string(num_removed_duplicates) << "' duplicates in cpu list.";
+        WARN << "Removed " << std::to_string(num_removed_duplicates)
+             << " duplicate entries in cpu list.";
     }
     thread_affinity_map.resize(std::distance(thread_affinity_map.begin(), ip));
 
@@ -378,14 +379,15 @@ std::vector<int> nervana::parse_cpu_list(const std::string& cpu_list)
                                     std::to_string(std::thread::hardware_concurrency()) + ").");
     }
 
-    if (thread_affinity_map.front() < 0)
-    {
-        throw std::invalid_argument("One or more indexes computed from cpu list '" + cpu_list +
-                                    "' are less than '0'. Use values "
-                                    "in "
-                                    "range <0, " +
-                                    std::to_string(std::thread::hardware_concurrency()) + ").");
-    }
+    // This should never happen, because it throws at stoi() when parsing
+    // if (thread_affinity_map.front() < 0)
+    // {
+    //     throw std::invalid_argument("One or more indexes computed from cpu list '" + cpu_list +
+    //                                 "' are less than '0'. Use values "
+    //                                 "in "
+    //                                 "range <0, " +
+    //                                 std::to_string(std::thread::hardware_concurrency()) + ").");
+    // }
 
     return thread_affinity_map;
 }

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -371,7 +371,7 @@ std::vector<int> nervana::parse_cpu_list(const std::string& cpu_list)
     }
     thread_affinity_map.resize(std::distance(thread_affinity_map.begin(), ip));
 
-    if (thread_affinity_map.back() > std::thread::hardware_concurrency())
+    if (thread_affinity_map.back() >= std::thread::hardware_concurrency())
     {
         throw std::invalid_argument("One or more indexes computed from cpu list '" + cpu_list +
                                     "' exceed number of logical cores. Use values "

--- a/src/util.hpp
+++ b/src/util.hpp
@@ -185,6 +185,9 @@ namespace nervana
     std::string vector2string(const std::vector<char>& s);
 
     std::vector<int> parse_cpu_list(const std::string& cpu_list);
+    std::vector<int> get_thread_affinity_map(const std::string& config_cpu_list,
+                                             int                max_count_of_free_threads,
+                                             int                free_threads_ratio);
 
     class stopwatch
     {

--- a/src/util.hpp
+++ b/src/util.hpp
@@ -184,6 +184,8 @@ namespace nervana
     std::vector<char> string2vector(const std::string& s);
     std::string vector2string(const std::vector<char>& s);
 
+    std::vector<int> parse_cpu_list(const std::string& cpu_list);
+
     class stopwatch
     {
     public:

--- a/test/test_buffer.cpp
+++ b/test/test_buffer.cpp
@@ -123,7 +123,7 @@ TEST(buffer, serialization)
                    {"batch_size", batch_size},
                    {"iteration_mode", "INFINITE"},
                    {"cache_directory", ""},
-                   {"decode_thread_count", 0},
+                   {"aeon_cpu_list", ""},
                    {"etl", {image_config, label_config}}};
 
     shared_ptr<nervana::provider_interface> provider = provider_factory::create(config);

--- a/test/test_loader.cpp
+++ b/test/test_loader.cpp
@@ -380,7 +380,7 @@ TEST(loader, provider)
     json label_config = {{"type", "label"}, {"binary", false}};
     json augmentation = {
         {{"height", height}, {"width", width}, {"type", "image"}, {"flip_enable", true}}};
-    json js = {{"decode_thread_count", 1},
+    json js = {{"cpu_list", "0"},
                {"manifest_filename", manifest},
                {"batch_size", batch_size},
                {"iteration_mode", "INFINITE"},
@@ -486,7 +486,7 @@ TEST(DISABLED_loader, deterministic)
                              {"manifest_filename", manifest},
                              {"batch_size", batch_size},
                              {"iteration_mode", "INFINITE"},
-                             {"decode_thread_count", 0},
+                             {"cpu_list", ""},
                              {"shuffle_manifest", true},
                              {"etl", {image_config, label_config}},
                              {"augmentation", aug_config},
@@ -655,7 +655,7 @@ TEST(benchmark, imagenet)
                        {"batch_size", batch_size},
                        {"iteration_mode", "INFINITE"},
                        {"cache_directory", cache_root},
-                       {"decode_thread_count", 0},
+                       {"cpu_list", ""},
                        //{"web_server_port", 8086},
                        {"etl", {image_config, label_config}},
                        {"augmentation", aug_config}};
@@ -743,7 +743,7 @@ TEST(benchmark, imagenet_paddle)
                        {"batch_size", batch_size},
                        {"iteration_mode", "INFINITE"},
                        {"cache_directory", cache_root},
-                       {"decode_thread_count", 0},
+                       {"cpu_list", ""},
                        {"etl", {image_config, label_config}},
                        {"augmentation", aug_config}};
 


### PR DESCRIPTION
Now thread affinity range can be specified through environment variable `AEON_CPU_LIST`.  Alternatively use `cpu_list` argument in loader config.

**Example:**
`AEON_CPU_LIST=5,10-12` 
`{cpu_list, "5,10-12"}`

the indexing starts at 0 like in *numa*. 
If unspecified, the cores are selected automatically .
