### PR TITLE
[do not merge] Floor crop

### DIFF
--- a/src/augment_image.cpp
+++ b/src/augment_image.cpp
@@ -218,7 +218,9 @@ shared_ptr<augment::image::params> augment::image::param_factory::make_params(
 
         cv::Point2i cropbox_origin =
             nervana::image::cropbox_shift(input_size, cropbox_size, c_off_x, c_off_y);
-        settings->cropbox = cv::Rect(cropbox_origin, cropbox_size);
+        settings->cropbox = cv::Rect(cropbox_origin,
+                                     cv::Size2i(static_cast<int>(cropbox_size.width),
+                                                static_cast<int>(cropbox_size.height)));
     }
 
     if (lighting.stddev() != 0)


### PR DESCRIPTION
This branch is adapting aeon's behavior to match more closely pyreader's behavior. The problem is 
This causes regression in crop_size - a unit test fails (`test/testsuite --gtest_filter=image.area_scale`).
If crop ratio is requested to be `0,3` then
the **output** cropbox_ratio is no longer `0.300011575` but `0.297222227` .