### PR TITLE
Add support for git tags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,19 +27,26 @@ if (NOT CMAKE_BUILD_TYPE)
         FORCE)
 endif()
 
-set(AEON_VERSION_MAJOR 1)
-set(AEON_VERSION_MINOR 3)
-set(AEON_VERSION_PATCH 3)
+# Set directory where the custom finders live
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/Modules/")
 
-set(AEON_BUILD_NUMBER 0)
+# Get actual aeon version number from sources
+include(AeonVersion)
 
-set(AEON_VERSION ${AEON_VERSION_MAJOR}.${AEON_VERSION_MINOR}.${AEON_VERSION_PATCH}
-                 CACHE STRING "AEON logical version")
+AEON_GET_VERSION_LABEL()
+
+string(REGEX MATCH "([0-9?]+)\\.([0-9?]+)\\.([0-9?]+)(-(rc|dev)\\.[0-9?]+)?" AEON_VERSION "${AEON_VERSION_LABEL}")
+string(REGEX REPLACE "-rc." "rc" AEON_VERSION "${AEON_VERSION}")
+string(REGEX REPLACE "-dev." "dev" AEON_VERSION "${AEON_VERSION}")
+string(REGEX MATCH "[^v](.*)" AEON_VERSION "${AEON_VERSION_LABEL}")
+string(REPLACE "." ";" AEON_VERSION_PARTS "${AEON_VERSION}")
+list(GET AEON_VERSION_PARTS 0 AEON_VERSION_MAJOR)
+list(GET AEON_VERSION_PARTS 1 AEON_VERSION_MINOR)
+list(GET AEON_VERSION_PARTS 2 AEON_VERSION_PATCH)
 
 add_definitions(-DBUILD_VERSION_MAJOR=${AEON_VERSION_MAJOR}
                 -DBUILD_VERSION_MINOR=${AEON_VERSION_MINOR}
-                -DBUILD_VERSION_PATCH=${AEON_VERSION_PATCH}
-                -DBUILD_BUILD_NUMBER=${AEON_BUILD_NUMBER})
+                -DBUILD_VERSION_PATCH=${AEON_VERSION_PATCH})
 
 option(ENABLE_AEON_SERVICE "Enable compilation of AEON Service" OFF)
 option(ENABLE_AEON_CLIENT "Enable compilation of AEON Client" ON)
@@ -52,15 +59,8 @@ if(APPLE)
     set(CMAKE_MACOSX_RPATH 1)
 endif()
 
-if(NOT ${POSTFIX_VERSION} STREQUAL "")
-    set(AEON_VERSION "${AEON_VERSION}${POSTFIX_VERSION}")
-endif()
-
 set(CMAKE_DISABLE_SOURCE_CHANGES ON)
 set(CMAKE_DISABLE_IN_SOURCE_BUILD ON)
-
-# set directory where the custom finders live
-set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/Modules/")
 
 option(COVERAGE "make code coverage" OFF)
 if(COVERAGE)

--- a/cmake/Modules/AeonVersion.cmake
+++ b/cmake/Modules/AeonVersion.cmake
@@ -1,0 +1,87 @@
+# ******************************************************************************
+# Copyright 2017-2019 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ******************************************************************************
+
+function(AEON_GET_CURRENT_HASH)
+    find_package(Git REQUIRED)
+    execute_process(
+        COMMAND ${GIT_EXECUTABLE} rev-parse --verify HEAD
+        RESULT_VARIABLE RESULT
+        OUTPUT_VARIABLE HASH
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+        ERROR_QUIET)
+
+    if(NOT HASH)
+        return()
+    endif()
+    string(STRIP ${HASH} HASH)
+    set(AEON_CURRENT_HASH ${HASH} PARENT_SCOPE)
+endfunction()
+
+function(AEON_GET_TAG_OF_CURRENT_HASH)
+    find_package(Git REQUIRED)
+    execute_process(
+        COMMAND ${GIT_EXECUTABLE} show-ref
+        RESULT_VARIABLE RESULT
+        OUTPUT_VARIABLE TAG_LIST
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+        ERROR_QUIET)
+
+    if (NOT ${TAG_LIST} STREQUAL "")
+        # first look for vX.Y.Z release tag
+        string(REGEX MATCH "${AEON_CURRENT_HASH}[\t ]+refs/tags/v([0-9?]+)\\.([0-9?]+)\\.([0-9?]+)$" TAG ${TAG_LIST})
+        if ("${TAG}" STREQUAL "")
+            # release tag not found so now look for vX.Y.Z-rc.N tag
+            string(REGEX MATCH "${AEON_CURRENT_HASH}[\t ]+refs/tags/v([0-9?]+)\\.([0-9?]+)\\.([0-9?]+)-(rc\\.[0-9?]+)$" TAG ${TAG_LIST})
+        endif()
+        if (NOT "${TAG}" STREQUAL "")
+            string(REGEX REPLACE "${AEON_CURRENT_HASH}[\t ]+refs/tags/(.*)" "\\1" FINAL_TAG ${TAG})
+        endif()
+    else()
+        set(FINAL_TAG "")
+    endif()
+    set(AEON_CURRENT_RELEASE_TAG ${FINAL_TAG} PARENT_SCOPE)
+endfunction()
+
+function(AEON_GET_MOST_RECENT_TAG)
+    find_package(Git REQUIRED)
+    execute_process(
+        COMMAND ${GIT_EXECUTABLE} describe --tags --abbrev=0 --match v*.*.*
+        RESULT_VARIABLE RESULT
+        OUTPUT_VARIABLE TAG
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+        ERROR_QUIET)
+
+    if (NOT ${TAG} STREQUAL "")
+        string(STRIP ${TAG} TAG)
+    endif()
+    set(AEON_MOST_RECENT_RELEASE_TAG ${TAG} PARENT_SCOPE)
+endfunction()
+
+function(AEON_GET_VERSION_LABEL)
+    AEON_GET_CURRENT_HASH()
+    AEON_GET_TAG_OF_CURRENT_HASH()
+
+    set(AEON_VERSION_LABEL ${AEON_CURRENT_RELEASE_TAG} PARENT_SCOPE)
+    if ("${AEON_CURRENT_RELEASE_TAG}" STREQUAL "")
+        AEON_GET_MOST_RECENT_TAG()
+        if (NOT ${AEON_MOST_RECENT_RELEASE_TAG} STREQUAL "")
+            set(AEON_VERSION_LABEL "${AEON_MOST_RECENT_RELEASE_TAG}" PARENT_SCOPE)
+        endif()
+    endif()
+
+    # export variable to the parent scope
+    set(AEON_CURRENT_HASH ${AEON_CURRENT_HASH} PARENT_SCOPE)
+endfunction()

--- a/src/setup.py.in
+++ b/src/setup.py.in
@@ -70,6 +70,10 @@ libs = libs.replace('-l', '').split()
 lib_dirs = lib_dirs.replace('-L','').split()
 extra_compile_args = "${CMAKE_CXX_FLAGS}".strip().split(' ')
 
+hashfile = open(os.path.join('${CMAKE_BINARY_DIR}','githash'),'w')
+hashfile.write('${AEON_CURRENT_HASH}')
+hashfile.close()
+
 
 module = Extension(
     'aeon',
@@ -82,8 +86,16 @@ module = Extension(
 
 setup(
     name='nervana-aeon',
-    version='${AEON_VERSION}',
     description='Framework-independent deep learning dataloader',
+    version='${AEON_VERSION}',
+    author='Intel Corporation',
+    author_email='intelnervana@intel.com',
+    url='https://github.com/NervanaSystems/aeon/',
     license='Intel Internal Use Software License Agreement',
-    ext_modules=[module]
+    long_description=open(os.path.join('${PROJECT_SOURCE_DIR}', 'README.md')).read(),
+    long_description_content_type='text/markdown',
+    keywords='Intel aeon data reader loader deep learning',
+    platforms='Linux',
+    ext_modules=[module],
+    data_files=[('extra_files', ['${CMAKE_BINARY_DIR}/githash'])]
 )


### PR DESCRIPTION
Changes:
1. Removed hardcoded aeon version from cmake file.
2. A wheel file have the version number as a git tag of the aeon source being built.
3. Adding more information to the metadata file.